### PR TITLE
Add create token endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,9 +43,10 @@ func main() {
 
 	// Interactors
 	createUser := interactors.NewCreateUser(logrus.Get("CreateUser"), userProxy)
+	createToken := interactors.NewCreateToken(logrus.Get("CreateToken"), userProxy)
 
 	// Controllers
-	userController := controllers.NewUserController(logrus.Get("Controller"), createUser)
+	userController := controllers.NewUserController(logrus.Get("Controller"), createUser, createToken)
 
 	// Server
 	serverChan := make(chan bool, 1)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -45,6 +45,36 @@ var doc = `{
                 }
             }
         },
+        "/tokens": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Generate a new user's token",
+                "parameters": [
+                    {
+                        "description": "User e-mail and password",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/entities.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "User's token",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.CreateTokenResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "post": {
                 "consumes": [
@@ -69,7 +99,7 @@ var doc = `{
                     "201": {
                         "description": "Message informing the user was created properly",
                         "schema": {
-                            "$ref": "#/definitions/controllers.StatusResponse"
+                            "$ref": "#/definitions/controllers.DetailedErrorResponse"
                         }
                     },
                     "409": {
@@ -95,7 +125,15 @@ var doc = `{
         }
     },
     "definitions": {
-        "controllers.StatusResponse": {
+        "controllers.CreateTokenResponse": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "controllers.DetailedErrorResponse": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -29,6 +29,36 @@
                 }
             }
         },
+        "/tokens": {
+            "post": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Generate a new user's token",
+                "parameters": [
+                    {
+                        "description": "User e-mail and password",
+                        "name": "user",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/entities.User"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "User's token",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.CreateTokenResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users": {
             "post": {
                 "consumes": [
@@ -53,7 +83,7 @@
                     "201": {
                         "description": "Message informing the user was created properly",
                         "schema": {
-                            "$ref": "#/definitions/controllers.StatusResponse"
+                            "$ref": "#/definitions/controllers.DetailedErrorResponse"
                         }
                     },
                     "409": {
@@ -79,7 +109,15 @@
         }
     },
     "definitions": {
-        "controllers.StatusResponse": {
+        "controllers.CreateTokenResponse": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
+        "controllers.DetailedErrorResponse": {
             "type": "object",
             "properties": {
                 "message": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,11 @@
 basePath: /
 definitions:
-  controllers.StatusResponse:
+  controllers.CreateTokenResponse:
+    properties:
+      token:
+        type: string
+    type: object
+  controllers.DetailedErrorResponse:
     properties:
       message:
         type: string
@@ -37,6 +42,25 @@ paths:
           schema:
             $ref: '#/definitions/server.Health'
       summary: Verify the service health
+  /tokens:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: User e-mail and password
+        in: body
+        name: user
+        required: true
+        schema:
+          $ref: '#/definitions/entities.User'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: User's token
+          schema:
+            $ref: '#/definitions/controllers.CreateTokenResponse'
+      summary: Generate a new user's token
   /users:
     post:
       consumes:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6657618d592d020e1db098f86cd955873cf0cb6dfb40375f0158786ad7ad3984
-updated: 2019-12-09T18:44:00.286606-03:00
+hash: 465234515d8d4d58797d120e18899a83c3b660fc031cca78bbd93ec4ace4dd3a
+updated: 2019-12-12T10:28:48.579109-03:00
 imports:
 - name: github.com/alecthomas/template
   version: fb15b899a75114aa79cc930e33c46b577cc664b1
@@ -65,6 +65,11 @@ imports:
   version: b5bf975e5823809fb22c7644d008757f78a4259e
 - name: github.com/streadway/amqp
   version: edfb9018d2714e4ec54dbaba37dbfef2bdadf0e4
+- name: github.com/stretchr/testify
+  version: 221dbe5ed46703ee255b1da0dec05086f5035f62
+  subpackages:
+  - assert
+  - mock
 - name: github.com/swaggo/files
   version: 630677cd5c140664e2ff6b53e75c289877268c69
 - name: github.com/swaggo/http-swagger
@@ -90,7 +95,7 @@ imports:
   - unicode/norm
   - width
 - name: golang.org/x/tools
-  version: 115af5e89bf7a8d9b991baffd7b86ec92ee403ab
+  version: 825cb0626375eeecd4d401e7f1653c1ec405d2c8
   subpackages:
   - go/ast/astutil
   - go/buildutil
@@ -111,8 +116,3 @@ testImports:
   - difflib
 - name: github.com/stretchr/objx
   version: 35313a95ee26395aa17d366c71a2ccf788fa69b6
-- name: github.com/stretchr/testify
-  version: 221dbe5ed46703ee255b1da0dec05086f5035f62
-  subpackages:
-  - assert
-  - mock

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,3 +14,5 @@ import:
   version: ^3.0.0
 - package: github.com/alecthomas/template
 - package: github.com/swaggo/http-swagger
+- package: github.com/stretchr/testify
+  version: v1.4.0

--- a/pkg/controllers/status_response.go
+++ b/pkg/controllers/status_response.go
@@ -1,6 +1,0 @@
-package controllers
-
-// StatusResponse represents the response to be sent to the request
-type StatusResponse struct {
-	Message string `json:"message"`
-}

--- a/pkg/controllers/user.go
+++ b/pkg/controllers/user.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
@@ -24,23 +23,33 @@ func NewUserController(
 	return &UserController{logger, createUserInteractor}
 }
 
-func (uc *UserController) writeResponse(w http.ResponseWriter, status int, err string) {
-	js, jsonErr := json.Marshal(StatusResponse{Message: err})
-	if jsonErr != nil {
-		uc.logger.Errorf("Unable to marshal json: %s", jsonErr)
+// DetailedErrorResponse represents the response to be sent to the request
+type DetailedErrorResponse struct {
+	Message string `json:"message"`
+}
+
+func (uc *UserController) writeResponse(w http.ResponseWriter, statusCode int, msg interface{}) {
+	w.WriteHeader(statusCode)
+
+	if msg == nil {
 		return
 	}
 
-	w.WriteHeader(status)
+	js, err := json.Marshal(msg)
+	if err != nil {
+		uc.logger.Errorf("Unable to marshal json: %s", err)
+		return
+	}
+
 	w.Header().Set("Content-Type", "application/json")
-	_, writeErr := w.Write(js)
-	if writeErr != nil {
-		uc.logger.Errorf("Unable to write to connection HTTP: %s", writeErr)
+	_, err = w.Write(js)
+	if err != nil {
+		uc.logger.Errorf("Unable to write to connection HTTP: %s", err)
 		return
 	}
 }
 
-func verifyErrorType(err error) int {
+func mapErrorToStatusCode(err error) int {
 	switch err.(type) {
 	case entities.ErrEntityExists:
 		return http.StatusConflict
@@ -63,28 +72,25 @@ func verifyErrorType(err error) int {
 func (uc *UserController) Create(w http.ResponseWriter, r *http.Request) {
 	var err error
 	var user entities.User
-	var decoder *json.Decoder
 
 	uc.logger.Debug("Handle request to create user")
 
-	decoder = json.NewDecoder(r.Body)
-
+	decoder := json.NewDecoder(r.Body)
 	err = decoder.Decode(&user)
 	if err != nil {
-		errStr := fmt.Sprintf("Invalid request format: %s", err)
-		uc.logger.Error(errStr)
-		uc.writeResponse(w, http.StatusUnprocessableEntity, errStr)
+		uc.logger.Error("Failed to parse request body")
+		uc.writeResponse(w, http.StatusUnprocessableEntity, nil)
 		return
 	}
 
 	err = uc.createUserInteractor.Execute(user)
 	if err != nil {
-		uc.logger.Errorf("Response error: %s", err)
-		uc.writeResponse(w, verifyErrorType(err), err.Error())
+		uc.logger.Errorf("Failed to create user")
+		der := &DetailedErrorResponse{err.Error()}
+		uc.writeResponse(w, mapErrorToStatusCode(err), der)
 		return
 	}
 
-	msg := fmt.Sprintf("User %s created", user.Email)
-	uc.logger.Info(msg)
-	uc.writeResponse(w, http.StatusCreated, msg)
+	uc.logger.Infof("User %s created", user.Email)
+	uc.writeResponse(w, http.StatusCreated, nil)
 }

--- a/pkg/entities/err_invalid_credentials.go
+++ b/pkg/entities/err_invalid_credentials.go
@@ -1,0 +1,10 @@
+package entities
+
+// ErrInvalidCredentials represents an error when the credentials is invalid
+type ErrInvalidCredentials struct {
+	Msg string
+}
+
+func (err ErrInvalidCredentials) Error() string {
+	return err.Msg
+}

--- a/pkg/interactors/create_token.go
+++ b/pkg/interactors/create_token.go
@@ -1,0 +1,31 @@
+package interactors
+
+import (
+	"github.com/CESARBR/knot-babeltower/pkg/entities"
+	"github.com/CESARBR/knot-babeltower/pkg/logging"
+	"github.com/CESARBR/knot-babeltower/pkg/network"
+)
+
+// CreateToken has all dependencies and methods to enable the create token use case
+// execution. It is composed by the logger and user proxy services.
+type CreateToken struct {
+	logger    logging.Logger
+	userProxy network.UserProxy
+}
+
+// NewCreateToken creates a new CreateToken instance by receiving its dependencies.
+func NewCreateToken(logger logging.Logger, userProxy network.UserProxy) *CreateToken {
+	return &CreateToken{logger, userProxy}
+}
+
+// Execute receives the user entity filled with e-mail and password properties and try
+// to create a token on the user proxy service. If it succeed, the token is returned.
+func (ct *CreateToken) Execute(user entities.User) (token string, err error) {
+	token, err = ct.userProxy.CreateToken(user)
+	if err != nil {
+		ct.logger.Errorf("Send request error: %s", err.Error())
+		return "", err
+	}
+
+	return token, err
+}

--- a/pkg/interactors/create_token_test.go
+++ b/pkg/interactors/create_token_test.go
@@ -1,0 +1,90 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/entities"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type FakeCreateTokenLogger struct{}
+
+type FakeTokenProxy struct {
+	mock.Mock
+}
+
+type CreateUserResponse struct {
+	token string
+	err   error
+}
+
+type CreateTokenTestCase struct {
+	name           string
+	email          string
+	password       string
+	fakeLogger     *FakeCreateTokenLogger
+	fakeTokenProxy *FakeTokenProxy
+	expected       CreateUserResponse
+}
+
+func (fl *FakeCreateTokenLogger) Info(...interface{}) {}
+
+func (fl *FakeCreateTokenLogger) Infof(string, ...interface{}) {}
+
+func (fl *FakeCreateTokenLogger) Debug(...interface{}) {}
+
+func (fl *FakeCreateTokenLogger) Warn(...interface{}) {}
+
+func (fl *FakeCreateTokenLogger) Error(...interface{}) {}
+
+func (fl *FakeCreateTokenLogger) Errorf(string, ...interface{}) {}
+
+func (ftp *FakeTokenProxy) Create(user entities.User) error {
+	return nil
+}
+
+func (ftp *FakeTokenProxy) CreateToken(user entities.User) (token string, err error) {
+	args := ftp.Called(user)
+	return args.String(0), args.Error(1)
+}
+
+var cases = []CreateTokenTestCase{
+	{
+		"success",
+		"fake@email.com",
+		"123456",
+		&FakeCreateTokenLogger{},
+		&FakeTokenProxy{},
+		CreateUserResponse{"mocked-token", nil},
+	},
+	{
+		"create-token-failed",
+		"fake@email.com",
+		"123456",
+		&FakeCreateTokenLogger{},
+		&FakeTokenProxy{},
+		CreateUserResponse{"", errors.New("failed to create token")},
+	},
+}
+
+func TestCreateToken(t *testing.T) {
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			user := entities.User{Email: tc.email, Password: tc.password}
+			tc.fakeTokenProxy.
+				On("CreateToken", user).
+				Return(tc.expected.token, tc.expected.err)
+
+			createTokenInteractor := NewCreateToken(tc.fakeLogger, tc.fakeTokenProxy)
+			token, err := createTokenInteractor.Execute(user)
+			if err != nil {
+				assert.Equal(t, tc.expected.token, token)
+				return
+			}
+
+			assert.Nil(t, err)
+		})
+	}
+}

--- a/pkg/interactors/create_user_test.go
+++ b/pkg/interactors/create_user_test.go
@@ -41,6 +41,10 @@ func (fup *FakeUserProxy) Create(user entities.User) (err error) {
 	return err
 }
 
+func (fup *FakeUserProxy) CreateToken(user entities.User) (string, error) {
+	return "", nil
+}
+
 func TestCreateUser(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/pkg/network/user_proxy.go
+++ b/pkg/network/user_proxy.go
@@ -14,12 +14,18 @@ import (
 // UserProxy proxy a request to the user service interface
 type UserProxy interface {
 	Create(user entities.User) (err error)
+	CreateToken(user entities.User) (string, error)
 }
 
 // Proxy proxy a request to the user service
 type Proxy struct {
 	url    string
 	logger logging.Logger
+}
+
+// TokenResponse represents the creating token response from the users service
+type TokenResponse struct {
+	Token string `json:"token"`
 }
 
 // NewUserProxy creates a proxy to the users service
@@ -54,4 +60,35 @@ func (p *Proxy) Create(user entities.User) (err error) {
 	}
 
 	return nil
+}
+
+// CreateToken genereates a token for the specified user
+func (p *Proxy) CreateToken(user entities.User) (string, error) {
+	var resp *http.Response
+
+	parsedCredentials, err := json.Marshal(user)
+	if err != nil {
+		return "", err
+	}
+
+	client := &http.Client{}
+	resp, err = client.Post(p.url+"/tokens", "application/json", bytes.NewBuffer(parsedCredentials))
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusForbidden {
+		msg := fmt.Sprintf("Invalid credentials")
+		return "", entities.ErrInvalidCredentials{Msg: msg}
+	}
+
+	tr := &TokenResponse{}
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(tr)
+	if err != nil {
+		return "", nil
+	}
+
+	return tr.Token, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -66,6 +66,7 @@ func (s *Server) createRouters() *mux.Router {
 	r := mux.NewRouter()
 	r.HandleFunc("/healthcheck", s.healthcheckHandler)
 	r.HandleFunc("/users", s.userController.Create).Methods("POST")
+	r.HandleFunc("/tokens", s.userController.CreateToken).Methods("POST")
 	r.PathPrefix("/swagger/").Handler(httpSwagger.Handler(
 		httpSwagger.URL("/swagger/doc.json"),
 	)).Methods("GET")


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
This patch adds the create user's token endpoint.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments?
-------------------
Nops.

Where has this been tested?
---------------------------

**Operating System/Platform:** macOS 10.14 - Darwin 18.0.0

**Go Version:** go1.12.7 darwin/amd64