### PR TITLE
Add message handler to register device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ app-*
 # Test binary, build with `go test -c`
 *.test
 
+# Output of coverage test
+coverage.html
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lint:
 
 .PHONY: cover
 cover:
-	${GOCMD} test -coverprofile=coverage.out ./... && ${GOCMD} tool cover -html=coverage.out
+	${GOCMD} test -coverprofile=coverage.out ./... && ${GOCMD} tool cover -html=coverage.out -o coverage.html
 
 .SILENT: clean
 .PHONY: clean

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -44,11 +44,12 @@ func main() {
 	// Services
 	userProxy := network.NewUserProxy(logrus.Get("UserProxy"), config.Users.Hostname, config.Users.Port)
 	thingProxy := network.NewThingProxy(logrus.Get("ThingProxy"), config.Things.Hostname, config.Things.Port)
+	connector := network.NewConnector(logrus.Get("Connector"), amqp)
 
 	// Interactors
 	createUser := interactors.NewCreateUser(logrus.Get("CreateUser"), userProxy)
 	createToken := interactors.NewCreateToken(logrus.Get("CreateToken"), userProxy)
-	registerThing := interactors.NewRegisterThing(logrus.Get("RegisterThing"), msgPublisher, thingProxy)
+	registerThing := interactors.NewRegisterThing(logrus.Get("RegisterThing"), msgPublisher, thingProxy, connector)
 
 	// Controllers
 	userController := controllers.NewUserController(logrus.Get("Controller"), createUser, createToken)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,9 +38,12 @@ func main() {
 	amqpChan := make(chan bool, 1)
 	amqp := network.NewAmqp(config.RabbitMQ.URL, logrus.Get("Amqp"))
 
+	// AMQP Publisher
+	msgPublisher := network.NewMsgPublisher(logrus.Get("MsgPublisher"), amqp)
+
 	// AMQP Handler
 	msgChan := make(chan bool, 1)
-	msgHandler := network.NewMsgHandler(logrus.Get("MsgHandler"), amqp)
+	msgHandler := network.NewMsgHandler(logrus.Get("MsgHandler"), amqp, msgPublisher)
 
 	// Services
 	userProxy := network.NewUserProxy(logrus.Get("UserProxy"), config.Users.Hostname, config.Users.Port)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,16 +41,13 @@ func main() {
 	// AMQP Publisher
 	msgPublisher := network.NewMsgPublisher(logrus.Get("MsgPublisher"), amqp)
 
-	// AMQP Handler
-	msgChan := make(chan bool, 1)
-	msgHandler := network.NewMsgHandler(logrus.Get("MsgHandler"), amqp, msgPublisher)
-
 	// Services
 	userProxy := network.NewUserProxy(logrus.Get("UserProxy"), config.Users.Hostname, config.Users.Port)
 
 	// Interactors
 	createUser := interactors.NewCreateUser(logrus.Get("CreateUser"), userProxy)
 	createToken := interactors.NewCreateToken(logrus.Get("CreateToken"), userProxy)
+	registerThing := interactors.NewRegisterThing(logrus.Get("RegisterThing"), msgPublisher)
 
 	// Controllers
 	userController := controllers.NewUserController(logrus.Get("Controller"), createUser, createToken)
@@ -58,6 +55,10 @@ func main() {
 	// Server
 	serverChan := make(chan bool, 1)
 	server := server.NewServer(config.Server.Port, logrus.Get("Server"), userController)
+
+	// AMQP Handler
+	msgChan := make(chan bool, 1)
+	msgHandler := network.NewMsgHandler(logrus.Get("MsgHandler"), amqp, registerThing)
 
 	// Start goroutines
 	go amqp.Start(amqpChan)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,11 +43,12 @@ func main() {
 
 	// Services
 	userProxy := network.NewUserProxy(logrus.Get("UserProxy"), config.Users.Hostname, config.Users.Port)
+	thingProxy := network.NewThingProxy(logrus.Get("ThingProxy"), config.Things.Hostname, config.Things.Port)
 
 	// Interactors
 	createUser := interactors.NewCreateUser(logrus.Get("CreateUser"), userProxy)
 	createToken := interactors.NewCreateToken(logrus.Get("CreateToken"), userProxy)
-	registerThing := interactors.NewRegisterThing(logrus.Get("RegisterThing"), msgPublisher)
+	registerThing := interactors.NewRegisterThing(logrus.Get("RegisterThing"), msgPublisher, thingProxy)
 
 	// Controllers
 	userController := controllers.NewUserController(logrus.Get("Controller"), createUser, createToken)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,12 +30,19 @@ type RabbitMQ struct {
 	URL string
 }
 
+// Things represents the things service to proxy request
+type Things struct {
+	Hostname string
+	Port     uint16
+}
+
 // Config represents the service configuration
 type Config struct {
 	Server
 	Logger
 	Users
 	RabbitMQ
+	Things
 }
 
 func readFile(name string) {

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -10,3 +10,7 @@ users:
 
 rabbitmq:
   url: amqp://localhost/
+
+things:
+  hostname: localhost
+  port: 8280

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -10,3 +10,7 @@ users:
 
 rabbitmq:
   url: amqp://localhost/
+
+things:
+  hostname: localhost
+  port: 8082

--- a/pkg/entities/err_no_perm.go
+++ b/pkg/entities/err_no_perm.go
@@ -1,0 +1,10 @@
+package entities
+
+// ErrNoPerm is a error when there is no permission to acess
+type ErrNoPerm struct {
+	Msg string
+}
+
+func (err ErrNoPerm) Error() string {
+	return err.Msg
+}

--- a/pkg/interactors/register_thing.go
+++ b/pkg/interactors/register_thing.go
@@ -160,7 +160,13 @@ func (rt *RegisterThing) Execute(id string, args ...interface{}) error {
 		return err
 	}
 
-	// TODO: wait connector reply
+	// Ignore message received and don't wait for response
+	go func(rt *RegisterThing) {
+		_, err := rt.connector.RecvRegisterDevice()
+		if err != nil {
+			rt.logger.Error(err)
+		}
+	}(rt)
 
 	return nil
 }

--- a/pkg/interactors/register_thing.go
+++ b/pkg/interactors/register_thing.go
@@ -23,8 +23,14 @@ type ErrorIDInvalid struct{}
 // ErrorNameNotFound is raised when Name is empty
 type ErrorNameNotFound struct{}
 
-// ErrorArgument is raised when Name is empty
-type ErrorArgument struct{ msg string }
+// ErrorUnauthorized is raised when authorization token is empty
+type ErrorUnauthorized struct{}
+
+// ErrorMissingArgument is raised there is some argument missing
+type ErrorMissingArgument struct{}
+
+// ErrorInvalidTypeArgument is raised when the type is the expected
+type ErrorInvalidTypeArgument struct{ msg string }
 
 func (err ErrorIDLenght) Error() string {
 	return "ID length error"
@@ -38,7 +44,15 @@ func (err ErrorNameNotFound) Error() string {
 	return "Name not found"
 }
 
-func (err ErrorArgument) Error() string {
+func (err ErrorUnauthorized) Error() string {
+	return "Authorization token not found"
+}
+
+func (err ErrorMissingArgument) Error() string {
+	return "Missing arguments"
+}
+
+func (err ErrorInvalidTypeArgument) Error() string {
 	return err.msg
 }
 
@@ -81,27 +95,36 @@ func (rt *RegisterThing) verifyThingID(id string) error {
 	return nil
 }
 
-func (rt *RegisterThing) verifyArguments(args ...interface{}) error {
-	if len(args) < 1 {
-		return ErrorArgument{"Missing argument name"}
+func (rt *RegisterThing) getArguments(args ...interface{}) (string, string, error) {
+	if len(args) < 2 {
+		return "", "", ErrorMissingArgument{}
 	}
 
 	name, ok := args[0].(string)
 	if !ok {
-		return ErrorArgument{msg: "Name is not string"}
+		return "", "", ErrorInvalidTypeArgument{msg: "Name is not string"}
 	}
 
 	if len(name) == 0 {
-		return ErrorNameNotFound{}
+		return "", "", ErrorNameNotFound{}
 	}
 
-	return nil
+	authorizationToken, ok := args[1].(string)
+	if !ok {
+		return "", "", ErrorInvalidTypeArgument{msg: "Authorization token is not string"}
+	}
+
+	if len(authorizationToken) == 0 {
+		return "", "", ErrorUnauthorized{}
+	}
+
+	return name, authorizationToken, nil
 }
 
 // Execute runs the use case
 func (rt *RegisterThing) Execute(id string, args ...interface{}) error {
 	rt.logger.Debug("Executing register thing use case")
-	err := rt.verifyArguments(args...)
+	name, authorizationToken, err := rt.getArguments(args...)
 	if err != nil {
 		errReply := rt.reply(id, "", err)
 		if errReply != nil {
@@ -113,13 +136,22 @@ func (rt *RegisterThing) Execute(id string, args ...interface{}) error {
 	}
 
 	err = rt.verifyThingID(id)
-	errReply := rt.reply(id, "", err)
+	if err != nil {
+		errReply := rt.reply(id, "", err)
+		if errReply != nil {
+			rt.logger.Error(errReply)
+		}
+
+		return err
+	}
+
+	// Get the id generated as a token and send in the response
+	token, err := rt.thingProxy.Create(id, name, authorizationToken)
+	errReply := rt.reply(id, token, err)
 	if errReply != nil {
 		rt.logger.Error(errReply)
 		return errReply
 	}
-
-	// TODO: add proxy request to token
 
 	return nil
 }

--- a/pkg/interactors/register_thing.go
+++ b/pkg/interactors/register_thing.go
@@ -1,0 +1,124 @@
+package interactors
+
+import (
+	"strconv"
+
+	"github.com/CESARBR/knot-babeltower/pkg/logging"
+	"github.com/CESARBR/knot-babeltower/pkg/network"
+)
+
+// RegisterThing use case to register a new thing
+type RegisterThing struct {
+	logger       logging.Logger
+	msgPublisher network.Publisher
+}
+
+// ErrorIDLenght is raised when ID is more than 16 characters
+type ErrorIDLenght struct{}
+
+// ErrorIDInvalid is raised when ID is not in hexadecimal value
+type ErrorIDInvalid struct{}
+
+// ErrorNameNotFound is raised when Name is empty
+type ErrorNameNotFound struct{}
+
+// ErrorArgument is raised when Name is empty
+type ErrorArgument struct{ msg string }
+
+func (err ErrorIDLenght) Error() string {
+	return "ID length error"
+}
+
+func (err ErrorIDInvalid) Error() string {
+	return "ID is not in hexadecimal"
+}
+
+func (err ErrorNameNotFound) Error() string {
+	return "Name not found"
+}
+
+func (err ErrorArgument) Error() string {
+	return err.msg
+}
+
+// NewRegisterThing contructs the use case
+func NewRegisterThing(logger logging.Logger, msgPublisher network.Publisher) *RegisterThing {
+	return &RegisterThing{logger, msgPublisher}
+}
+
+func (rt *RegisterThing) reply(id, token string, err error) error {
+	var errStr *string
+
+	if err != nil {
+		errStr = new(string)
+		*errStr = err.Error()
+	} else {
+		errStr = nil
+	}
+
+	response := network.RegisterResponseMsg{ID: id, Token: token, Error: errStr}
+	errPublish := rt.msgPublisher.SendRegisterDevice(response)
+	if errPublish != nil {
+		rt.logger.Error(errPublish)
+		return errPublish
+	}
+
+	return nil
+}
+
+func (rt *RegisterThing) verifyThingID(id string) error {
+	if len(id) > 16 {
+		return ErrorIDLenght{}
+	}
+
+	_, err := strconv.ParseUint(id, 16, 64)
+	if err != nil {
+		rt.logger.Error(err)
+		return ErrorIDInvalid{}
+	}
+
+	return nil
+}
+
+func (rt *RegisterThing) verifyArguments(args ...interface{}) error {
+	if len(args) < 1 {
+		return ErrorArgument{"Missing argument name"}
+	}
+
+	name, ok := args[0].(string)
+	if !ok {
+		return ErrorArgument{msg: "Name is not string"}
+	}
+
+	if len(name) == 0 {
+		return ErrorNameNotFound{}
+	}
+
+	return nil
+}
+
+// Execute runs the use case
+func (rt *RegisterThing) Execute(id string, args ...interface{}) error {
+	rt.logger.Debug("Executing register thing use case")
+	err := rt.verifyArguments(args...)
+	if err != nil {
+		errReply := rt.reply(id, "", err)
+		if errReply != nil {
+			rt.logger.Error(errReply)
+			return errReply
+		}
+
+		return err
+	}
+
+	err = rt.verifyThingID(id)
+	errReply := rt.reply(id, "", err)
+	if errReply != nil {
+		rt.logger.Error(errReply)
+		return errReply
+	}
+
+	// TODO: add proxy request to token
+
+	return nil
+}

--- a/pkg/interactors/register_thing.go
+++ b/pkg/interactors/register_thing.go
@@ -12,6 +12,7 @@ type RegisterThing struct {
 	logger       logging.Logger
 	msgPublisher network.Publisher
 	thingProxy   network.ThingProxy
+	connector    network.Connector
 }
 
 // ErrorIDLenght is raised when ID is more than 16 characters
@@ -57,8 +58,8 @@ func (err ErrorInvalidTypeArgument) Error() string {
 }
 
 // NewRegisterThing contructs the use case
-func NewRegisterThing(logger logging.Logger, msgPublisher network.Publisher, thingProxy network.ThingProxy) *RegisterThing {
-	return &RegisterThing{logger, msgPublisher, thingProxy}
+func NewRegisterThing(logger logging.Logger, msgPublisher network.Publisher, thingProxy network.ThingProxy, connector network.Connector) *RegisterThing {
+	return &RegisterThing{logger, msgPublisher, thingProxy, connector}
 }
 
 func (rt *RegisterThing) reply(id, token string, err error) error {
@@ -152,6 +153,14 @@ func (rt *RegisterThing) Execute(id string, args ...interface{}) error {
 		rt.logger.Error(errReply)
 		return errReply
 	}
+
+	err = rt.connector.SendRegisterDevice(id, name)
+	if err != nil {
+		rt.logger.Error(err)
+		return err
+	}
+
+	// TODO: wait connector reply
 
 	return nil
 }

--- a/pkg/interactors/register_thing.go
+++ b/pkg/interactors/register_thing.go
@@ -11,6 +11,7 @@ import (
 type RegisterThing struct {
 	logger       logging.Logger
 	msgPublisher network.Publisher
+	thingProxy   network.ThingProxy
 }
 
 // ErrorIDLenght is raised when ID is more than 16 characters
@@ -42,8 +43,8 @@ func (err ErrorArgument) Error() string {
 }
 
 // NewRegisterThing contructs the use case
-func NewRegisterThing(logger logging.Logger, msgPublisher network.Publisher) *RegisterThing {
-	return &RegisterThing{logger, msgPublisher}
+func NewRegisterThing(logger logging.Logger, msgPublisher network.Publisher, thingProxy network.ThingProxy) *RegisterThing {
+	return &RegisterThing{logger, msgPublisher, thingProxy}
 }
 
 func (rt *RegisterThing) reply(id, token string, err error) error {

--- a/pkg/interactors/register_thing_test.go
+++ b/pkg/interactors/register_thing_test.go
@@ -1,0 +1,119 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/network"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type registerTestSuite struct {
+	testArguments bool
+	thingID       string
+	thingName     interface{}
+	authorization interface{}
+	fakeLogger    *FakeRegisterThingLogger
+	fakePublisher *FakeMsgPublisher
+	errExpected   error
+}
+
+type FakeRegisterThingLogger struct {
+}
+
+type FakeMsgPublisher struct {
+	mock.Mock
+	sendError error
+	returnErr error
+}
+
+func (fl *FakeRegisterThingLogger) Info(...interface{}) {}
+
+func (fl *FakeRegisterThingLogger) Infof(string, ...interface{}) {}
+
+func (fl *FakeRegisterThingLogger) Debug(...interface{}) {}
+
+func (fl *FakeRegisterThingLogger) Warn(...interface{}) {}
+
+func (fl *FakeRegisterThingLogger) Error(...interface{}) {}
+
+func (fl *FakeRegisterThingLogger) Errorf(string, ...interface{}) {}
+
+func (fp *FakeMsgPublisher) SendRegisterDevice(msg network.RegisterResponseMsg) error {
+	ret := fp.Called(msg)
+
+	return ret.Error(0)
+}
+
+func TestRegisterThing(t *testing.T) {
+	testCases := map[string]registerTestSuite{
+		"TestPublisherError": {
+			false,
+			"123",
+			"test",
+			"authorization token",
+			&FakeRegisterThingLogger{},
+			&FakeMsgPublisher{returnErr: errors.New("mock publisher error")},
+			errors.New("mock publisher error"),
+		},
+		"TestIDLenght": {
+			false,
+			"01234567890123456789",
+			"test",
+			"authorization token",
+			&FakeRegisterThingLogger{},
+			&FakeMsgPublisher{sendError: ErrorIDLenght{}},
+			ErrorIDLenght{},
+		},
+		"TestNameEmpty": {
+			false,
+			"123",
+			"",
+			"authorization token",
+			&FakeRegisterThingLogger{},
+			&FakeMsgPublisher{sendError: ErrorNameNotFound{}},
+			ErrorNameNotFound{},
+		},
+		"TestIDInvalid": {
+			false,
+			"not hex string",
+			"test",
+			"authorization token",
+			&FakeRegisterThingLogger{},
+			&FakeMsgPublisher{sendError: ErrorIDInvalid{}},
+			ErrorIDInvalid{},
+		},
+	}
+
+	t.Logf("Number of test cases: %d", len(testCases))
+	for tcName, tc := range testCases {
+		t.Logf("Test case %s", tcName)
+		t.Run(tcName, func(t *testing.T) {
+			var err error
+			var tmp *string
+			if tc.fakePublisher.sendError != nil {
+				tmp = new(string)
+				*tmp = tc.fakePublisher.sendError.Error()
+			}
+
+			msg := network.RegisterResponseMsg{ID: tc.thingID, Token: "", Error: tmp}
+			tc.fakePublisher.On("SendRegisterDevice", msg).
+				Return(tc.fakePublisher.returnErr)
+			createThingInteractor := NewRegisterThing(tc.fakeLogger, tc.fakePublisher)
+			if tc.testArguments {
+				err = createThingInteractor.Execute(tc.thingID)
+			} else {
+				err = createThingInteractor.Execute(tc.thingID, tc.thingName, tc.authorization)
+			}
+
+			if err != nil && !assert.IsType(t, err, tc.errExpected) {
+				t.Errorf("Create Thing failed with unexpected error. Error: %s", err)
+				return
+			}
+
+			tc.fakePublisher.AssertExpectations(t)
+			t.Log("Create thing ok")
+		})
+	}
+}

--- a/pkg/interactors/register_thing_test.go
+++ b/pkg/interactors/register_thing_test.go
@@ -71,6 +71,16 @@ func TestRegisterThing(t *testing.T) {
 			&FakeProxy{},
 			errors.New("mock publisher error"),
 		},
+		"TestProxyError": {
+			false,
+			"123",
+			"test",
+			"authorization token",
+			&FakeRegisterThingLogger{},
+			&FakeMsgPublisher{token: "", sendError: errors.New("mock proxy error")},
+			&FakeProxy{returnError: errors.New("mock proxy error")},
+			errors.New("mock proxy error"),
+		},
 		"TestIDLenght": {
 			false,
 			"01234567890123456789",

--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -82,7 +82,7 @@ func (a *Amqp) declareQueue(name string) error {
 
 func convertDeliveryToInMsg(deliveries <-chan amqp.Delivery, outMsg chan InMsg) {
 	for d := range deliveries {
-		outMsg <- InMsg{d.Exchange, d.RoutingKey, d.Body}
+		outMsg <- InMsg{d.Exchange, d.RoutingKey, d.Headers, d.Body}
 	}
 }
 

--- a/pkg/network/connector.go
+++ b/pkg/network/connector.go
@@ -1,0 +1,41 @@
+package network
+
+import (
+	"encoding/json"
+
+	"github.com/CESARBR/knot-babeltower/pkg/logging"
+)
+
+const (
+	exchangeConnIn = "connIn"
+	registerInKey  = "device.register"
+)
+
+type connector struct {
+	logger logging.Logger
+	amqp   *Amqp
+}
+
+// Connector handle messages received from a service
+type Connector interface {
+	SendRegisterDevice(string, string) error
+}
+
+// NewConnector constructs the Connector
+func NewConnector(logger logging.Logger, amqp *Amqp) Connector {
+	return &connector{logger, amqp}
+}
+
+// SendRegisterDevice sends a registered message
+func (mp *connector) SendRegisterDevice(id string, name string) error {
+	mp.logger.Debug("Sending register message")
+
+	msg := RegisterRequestMsg{id, name}
+	bytes, err := json.Marshal(msg)
+	if err != nil {
+		mp.logger.Error(err)
+		return err
+	}
+	// TODO: receive message
+	return mp.amqp.PublishPersistentMessage(exchangeConnIn, registerInKey, bytes)
+}

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -1,0 +1,8 @@
+package network
+
+// InMsg represents the message received from the AMQP broker
+type InMsg struct {
+	Exchange   string
+	RoutingKey string
+	Body       []byte
+}

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -6,3 +6,16 @@ type InMsg struct {
 	RoutingKey string
 	Body       []byte
 }
+
+// RegisterRequestMsg is received to register a device
+type RegisterRequestMsg struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// RegisterResponseMsg is sent when receive a register request
+type RegisterResponseMsg struct {
+	ID    string  `json:"id"`
+	Token string  `json:"token"`
+	Error *string `json:"error"`
+}

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -4,6 +4,7 @@ package network
 type InMsg struct {
 	Exchange   string
 	RoutingKey string
+	Headers    map[string]interface{}
 	Body       []byte
 }
 

--- a/pkg/network/msg_handler.go
+++ b/pkg/network/msg_handler.go
@@ -2,10 +2,24 @@ package network
 
 import "github.com/CESARBR/knot-babeltower/pkg/logging"
 
+const (
+	queueNameFogIn  = "fogIn-messages"
+	exchangeFogIn   = "fogIn"
+	bindingKeyFogIn = "device.*"
+)
+
 // MsgHandler handle messages received from a service
 type MsgHandler struct {
 	logger logging.Logger
 	amqp   *Amqp
+}
+
+func (mc *MsgHandler) onMsgReceived(msgChan chan InMsg) {
+	for {
+		msg := <-msgChan
+		mc.logger.Infof("Exchange: %s, routing key: %s", msg.Exchange, msg.RoutingKey)
+		mc.logger.Infof("Message received: %s", string(msg.Body))
+	}
 }
 
 // NewMsgHandler constructs the MsgHandler
@@ -16,6 +30,17 @@ func NewMsgHandler(logger logging.Logger, amqp *Amqp) *MsgHandler {
 // Start starts to listen for messages
 func (mc *MsgHandler) Start(started chan bool) {
 	mc.logger.Debug("Msg handler started")
+
+	msgChan := make(chan InMsg)
+	err := mc.amqp.OnMessage(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyFogIn)
+	if err != nil {
+		mc.logger.Error(err)
+		started <- false
+		return
+	}
+
+	go mc.onMsgReceived(msgChan)
+
 	started <- true
 }
 

--- a/pkg/network/msg_handler.go
+++ b/pkg/network/msg_handler.go
@@ -1,0 +1,25 @@
+package network
+
+import "github.com/CESARBR/knot-babeltower/pkg/logging"
+
+// MsgHandler handle messages received from a service
+type MsgHandler struct {
+	logger logging.Logger
+	amqp   *Amqp
+}
+
+// NewMsgHandler constructs the MsgHandler
+func NewMsgHandler(logger logging.Logger, amqp *Amqp) *MsgHandler {
+	return &MsgHandler{logger, amqp}
+}
+
+// Start starts to listen for messages
+func (mc *MsgHandler) Start(started chan bool) {
+	mc.logger.Debug("Msg handler started")
+	started <- true
+}
+
+// Stop stops to listen for messages
+func (mc *MsgHandler) Stop() {
+	mc.logger.Debug("Msg handler stopped")
+}

--- a/pkg/network/msg_publisher.go
+++ b/pkg/network/msg_publisher.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	exchangeFogOut = "FogOut"
+	exchangeFogOut = "fogOut"
 	registerOutKey = "device.registered"
 )
 

--- a/pkg/network/msg_publisher.go
+++ b/pkg/network/msg_publisher.go
@@ -17,6 +17,11 @@ type MsgPublisher struct {
 	amqp   *Amqp
 }
 
+// Publisher is the interface with methods that the publisher should have
+type Publisher interface {
+	SendRegisterDevice(RegisterResponseMsg) error
+}
+
 // NewMsgPublisher constructs the MsgPublisher
 func NewMsgPublisher(logger logging.Logger, amqp *Amqp) *MsgPublisher {
 	return &MsgPublisher{logger, amqp}

--- a/pkg/network/msg_publisher.go
+++ b/pkg/network/msg_publisher.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"encoding/json"
+
+	"github.com/CESARBR/knot-babeltower/pkg/logging"
+)
+
+const (
+	exchangeFogOut = "FogOut"
+	registerOutKey = "device.registered"
+)
+
+// MsgPublisher handle messages received from a service
+type MsgPublisher struct {
+	logger logging.Logger
+	amqp   *Amqp
+}
+
+// NewMsgPublisher constructs the MsgPublisher
+func NewMsgPublisher(logger logging.Logger, amqp *Amqp) *MsgPublisher {
+	return &MsgPublisher{logger, amqp}
+}
+
+// SendRegisterDevice sends a registered message
+func (mp *MsgPublisher) SendRegisterDevice(msg RegisterResponseMsg) error {
+	mp.logger.Debug("Sending register message")
+
+	jsonMsg, err := json.Marshal(msg)
+	if err != nil {
+		mp.logger.Error(err)
+		return err
+	}
+
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, registerOutKey, jsonMsg)
+}

--- a/pkg/network/thing_proxy.go
+++ b/pkg/network/thing_proxy.go
@@ -1,8 +1,13 @@
 package network
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"time"
 
+	"github.com/CESARBR/knot-babeltower/pkg/entities"
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
 )
 
@@ -16,6 +21,29 @@ type proxy struct {
 	logger logging.Logger
 }
 
+type objKnot struct {
+	ID string `json:"id"`
+}
+
+type objMetadata struct {
+	Knot objKnot `json:"knot"`
+}
+
+func (p proxy) getJSONBody(id, name string) ([]byte, error) {
+	body := struct {
+		Name     string      `json:"name"`
+		Metadata objMetadata `json:"metadata"`
+	}{
+		Name: name,
+		Metadata: objMetadata{
+			Knot: objKnot{
+				ID: id,
+			},
+		},
+	}
+	return json.Marshal(body)
+}
+
 // NewThingProxy creates a proxy to the thing service
 func NewThingProxy(logger logging.Logger, hostname string, port uint16) ThingProxy {
 	url := fmt.Sprintf("http://%s:%d", hostname, port)
@@ -24,8 +52,49 @@ func NewThingProxy(logger logging.Logger, hostname string, port uint16) ThingPro
 	return proxy{url, logger}
 }
 
-// Create proxy the http request to thing service
+// Create registers a thing on service and return the id generated
 func (p proxy) Create(id, name, authorization string) (idGenerated string, err error) {
 	p.logger.Debug("Proxying request to create thing")
-	return idGenerated, nil
+	/**
+	 * Add Timeout in http.Client to avoid blocking the request.
+	 */
+	client := &http.Client{Timeout: 10 * time.Second}
+	jsonBody, err := p.getJSONBody(id, name)
+	if err != nil {
+		p.logger.Error(err)
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", p.url+"/things", bytes.NewBuffer(jsonBody))
+	if err != nil {
+		p.logger.Error(err)
+		return "", err
+	}
+
+	req.Header.Set("Authorization", authorization)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		p.logger.Error(err)
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		p.logger.Errorf("Status not created: %d", resp.StatusCode)
+		switch resp.StatusCode {
+		case http.StatusConflict:
+			// TODO: Verify uniqueness from KNoT ID
+			err = entities.ErrEntityExists{Msg: "Thing exists"}
+		case http.StatusForbidden:
+			err = entities.ErrNoPerm{Msg: "The authorization token has no permission to create a thing"}
+		}
+		return "", err
+	}
+
+	locationHeader := resp.Header.Get("Location")
+	idGenerated = locationHeader[len("/things/"):] // get substring after "/things/"
+
+	return idGenerated, err
 }

--- a/pkg/network/thing_proxy.go
+++ b/pkg/network/thing_proxy.go
@@ -1,0 +1,31 @@
+package network
+
+import (
+	"fmt"
+
+	"github.com/CESARBR/knot-babeltower/pkg/logging"
+)
+
+// ThingProxy proxy a request to the thing service interface
+type ThingProxy interface {
+	Create(id, name, authorization string) (idGenerated string, err error)
+}
+
+type proxy struct {
+	url    string
+	logger logging.Logger
+}
+
+// NewThingProxy creates a proxy to the thing service
+func NewThingProxy(logger logging.Logger, hostname string, port uint16) ThingProxy {
+	url := fmt.Sprintf("http://%s:%d", hostname, port)
+
+	logger.Debug("Proxy setup to " + url)
+	return proxy{url, logger}
+}
+
+// Create proxy the http request to thing service
+func (p proxy) Create(id, name, authorization string) (idGenerated string, err error) {
+	p.logger.Debug("Proxying request to create thing")
+	return idGenerated, nil
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
Add the messages handler incoming from Rabbitmq and proxy them to mainflux-things service.

Does this close any currently open issues?
------------------------------------------
No

Where has this been tested?
---------------------------

**Operating System/Platform:** Linux novavicosa 4.15.0-72-generic #81-Ubuntu SMP x86_64 x86_64 x86_64 GNU/Linux

**Go Version:** go version go1.13.3 linux/amd64
