### PR TITLE
system: interrupt: Exit after clean up

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,6 +88,7 @@ func main() {
 			msgHandler.Stop()
 			amqp.Stop()
 			server.Stop()
+			os.Exit(0)
 		}
 	}
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
-----------------------------------------------------
When running the application on the macOS I notice it wasn't exiting after ctrl+c pressed. This patch fixes this bug by calling explicitly a system's command to stop it.