### PR TITLE
thing: handler: Fix register call parameter order

### DIFF
--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -28,7 +28,7 @@ func (mc *MsgHandler) handleRegisterMsg(body []byte, authorizationHeader string)
 		return err
 	}
 
-	return mc.thingInteractor.Register(msgParsed.ID, msgParsed.Name, authorizationHeader)
+	return mc.thingInteractor.Register(authorizationHeader, msgParsed.ID, msgParsed.Name)
 }
 
 func (mc *MsgHandler) onMsgReceived(msgChan chan network.InMsg) {


### PR DESCRIPTION
What does this implement/fix?
---------------------------------------------------
This patch fixes the parameter order when calling the register thing interactor.

