### PR TITLE
refactor: thing: Move testing mocks

### DIFF
--- a/pkg/thing/interactors/update_schema_test.go
+++ b/pkg/thing/interactors/update_schema_test.go
@@ -4,26 +4,10 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/CESARBR/knot-babeltower/pkg/network"
-	"github.com/CESARBR/knot-babeltower/pkg/thing/delivery/http"
 	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/mocks"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-type FakeUpdateSchemaLogger struct{}
-
-type FakeThingProxy struct {
-	mock.Mock
-}
-
-type FakePublisher struct {
-	mock.Mock
-}
-
-type FakeThingConnector struct {
-	mock.Mock
-}
 
 type UpdateSchemaTestCase struct {
 	name                          string
@@ -34,62 +18,13 @@ type UpdateSchemaTestCase struct {
 	expectedSchemaResponse        error
 	expectedUpdatedSchema         error
 	expectedUpdateSchemaConnector error
-	fakeLogger                    *FakeUpdateSchemaLogger
-	fakeThingProxy                *FakeThingProxy
-	fakePublisher                 *FakePublisher
-	fakeConnector                 *FakeThingConnector
+	fakeLogger                    *mocks.FakeLogger
+	fakeThingProxy                *mocks.FakeThingProxy
+	fakePublisher                 *mocks.FakePublisher
+	fakeConnector                 *mocks.FakeConnector
 }
 
-func (fl *FakeUpdateSchemaLogger) Info(...interface{}) {}
-
-func (fl *FakeUpdateSchemaLogger) Infof(string, ...interface{}) {}
-
-func (fl *FakeUpdateSchemaLogger) Debug(...interface{}) {}
-
-func (fl *FakeUpdateSchemaLogger) Warn(...interface{}) {}
-
-func (fl *FakeUpdateSchemaLogger) Error(...interface{}) {}
-
-func (fl *FakeUpdateSchemaLogger) Errorf(string, ...interface{}) {}
-
-func (ftp *FakeThingProxy) Create(id, name, authorization string) (idGenerated string, err error) {
-	return "", nil
-}
-
-func (ftp *FakeThingProxy) UpdateSchema(authorization, thingID string, schema []entities.Schema) error {
-	args := ftp.Called(thingID, schema)
-	return args.Error(0)
-}
-
-func (ftp *FakeThingProxy) Get(authorization, thingID string) (*http.ThingProxyRepr, error) {
-	return nil, nil
-}
-
-func (fp *FakePublisher) SendRegisterDevice(network.RegisterResponseMsg) error {
-	return nil
-}
-
-func (fp *FakePublisher) SendUpdatedSchema(thingID string) error {
-	args := fp.Called(thingID)
-	return args.Error(0)
-}
-
-func (fc *FakeThingConnector) SendRegisterDevice(id, name string) (err error) {
-	ret := fc.Called(id, name)
-	return ret.Error(0)
-}
-
-func (fc *FakeThingConnector) SendUpdateSchema(id string, schemaList []entities.Schema) (err error) {
-	ret := fc.Called(id, schemaList)
-	return ret.Error(0)
-}
-
-func (fc *FakeThingConnector) RecvRegisterDevice() (bytes []byte, err error) {
-	ret := fc.Called()
-	return bytes, ret.Error(1)
-}
-
-var cases = []UpdateSchemaTestCase{
+var tCases = []UpdateSchemaTestCase{
 	{
 		"schema successfully updated on the thing's proxy",
 		"authorization token",
@@ -107,10 +42,10 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		nil,
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"failed to update the schema on the thing's proxy",
@@ -129,10 +64,10 @@ var cases = []UpdateSchemaTestCase{
 		errors.New("failed to update schema"),
 		nil,
 		nil,
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"schema response successfully sent",
@@ -151,10 +86,10 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		nil,
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"failed to send updated schema response",
@@ -173,10 +108,10 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		errors.New("failed to send updated schema response"),
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"failed to send update schema to connector",
@@ -195,10 +130,10 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		errors.New("failed to send update schema to connector"),
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"invalid schema type ID",
@@ -217,10 +152,10 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		nil,
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"invalid schema unit",
@@ -239,10 +174,10 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		nil,
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 	{
 		"invalid schema name",
@@ -261,15 +196,15 @@ var cases = []UpdateSchemaTestCase{
 		nil,
 		nil,
 		nil,
-		&FakeUpdateSchemaLogger{},
-		&FakeThingProxy{},
-		&FakePublisher{},
-		&FakeThingConnector{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
 	},
 }
 
 func TestUpdateSchema(t *testing.T) {
-	for _, tc := range cases {
+	for _, tc := range tCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.fakeThingProxy.
 				On("UpdateSchema", tc.thingID, tc.schemaList).

--- a/pkg/thing/mocks/connector.go
+++ b/pkg/thing/mocks/connector.go
@@ -1,0 +1,31 @@
+package mocks
+
+import (
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/stretchr/testify/mock"
+)
+
+// FakeConnector represents a mocking type for the connector service
+type FakeConnector struct {
+	mock.Mock
+	SendError error
+	RecvError error
+}
+
+// SendRegisterDevice provides a mock function to send register device command to connector
+func (fc *FakeConnector) SendRegisterDevice(id, name string) (err error) {
+	ret := fc.Called(id, name)
+	return ret.Error(0)
+}
+
+// SendUpdateSchema provides a mock function to send an update schema command to connector
+func (fc *FakeConnector) SendUpdateSchema(id string, schemaList []entities.Schema) (err error) {
+	ret := fc.Called(id, schemaList)
+	return ret.Error(0)
+}
+
+// RecvRegisterDevice provides a mock function to receive a register device confirmation from connector
+func (fc *FakeConnector) RecvRegisterDevice() (bytes []byte, err error) {
+	ret := fc.Called()
+	return bytes, ret.Error(1)
+}

--- a/pkg/thing/mocks/logger.go
+++ b/pkg/thing/mocks/logger.go
@@ -1,0 +1,22 @@
+package mocks
+
+// FakeLogger represents a mocking type for the logging service
+type FakeLogger struct{}
+
+// Info provides a mock function for the debugging Info capability
+func (fl *FakeLogger) Info(...interface{}) {}
+
+// Infof provides a mock function for the debugging Info capability
+func (fl *FakeLogger) Infof(string, ...interface{}) {}
+
+// Debug provides a mock function for the debugging Info capability
+func (fl *FakeLogger) Debug(...interface{}) {}
+
+// Warn provides a mock function for the debugging Info capability
+func (fl *FakeLogger) Warn(...interface{}) {}
+
+// Error provides a mock function for the debugging Info capability
+func (fl *FakeLogger) Error(...interface{}) {}
+
+// Errorf provides a mock function for the debugging Info capability
+func (fl *FakeLogger) Errorf(string, ...interface{}) {}

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -1,0 +1,33 @@
+package mocks
+
+import (
+	"github.com/CESARBR/knot-babeltower/pkg/network"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/stretchr/testify/mock"
+)
+
+// FakePublisher represents a mocking type for the publisher service
+type FakePublisher struct {
+	mock.Mock
+	ReturnErr error
+	SendError error
+	Token     string
+}
+
+// SendRegisterDevice provides a mock function to send a register device response
+func (fp *FakePublisher) SendRegisterDevice(msg network.RegisterResponseMsg) error {
+	ret := fp.Called(msg)
+	return ret.Error(0)
+}
+
+// SendUpdatedSchema provides a mock function to send an update schema response
+func (fp *FakePublisher) SendUpdatedSchema(thingID string) error {
+	ret := fp.Called(thingID)
+	return ret.Error(0)
+}
+
+// SendThings provides a mock function to send a list things response
+func (fp *FakePublisher) SendThings(things []*entities.Thing) error {
+	args := fp.Called(things)
+	return args.Error(0)
+}

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -1,0 +1,35 @@
+package mocks
+
+import (
+	"github.com/CESARBR/knot-babeltower/pkg/thing/delivery/http"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/stretchr/testify/mock"
+)
+
+// FakeThingProxy represents a mocking type for the thing's proxy service
+type FakeThingProxy struct {
+	mock.Mock
+	ReturnErr error
+}
+
+// Create provides a mock function to create a thing on the thing's seervice
+func (ftp *FakeThingProxy) Create(id, name, authorization string) (idGenerated string, err error) {
+	ret := ftp.Called(id, name, authorization)
+	return ret.String(0), ret.Error(1)
+}
+
+// UpdateSchema provides a mock function to update thing's schema on the thing's service
+func (ftp *FakeThingProxy) UpdateSchema(authorization, thingID string, schema []entities.Schema) error {
+	ret := ftp.Called(thingID, schema)
+	return ret.Error(0)
+}
+
+// Get provides a mock function to receive a thing from the thing's service
+func (ftp *FakeThingProxy) Get(authorization, thingID string) (*http.ThingProxyRepr, error) {
+	return nil, nil
+}
+
+// List provides a mock function to list things from the thing's service
+func (ftp *FakeThingProxy) List(authorization string) ([]*entities.Thing, error) {
+	return nil, nil
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
In order to improve the unit tests readability, this commit moves the
interface mocks to a specific directory so that they can be reused by
many test suites.