### PR TITLE
Add request data command

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -36,3 +36,9 @@ type UpdatedSchemaResponse struct {
 type ListThingsResponse struct {
 	Things []*entities.Thing `json:"things"`
 }
+
+// RequestDataCommand represents the request data command
+type RequestDataCommand struct {
+	ID        string `json:"id"`
+	SensorIds []int  `json:"sensorIds"`
+}

--- a/pkg/thing/delivery/amqp/msg_publisher.go
+++ b/pkg/thing/delivery/amqp/msg_publisher.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	exchangeFogOut   = "fogOut"
-	registerOutKey   = "device.registered"
-	schemaOutKey     = "schema.updated"
-	listThingsOutKey = "device.list"
+	exchangeFogOut    = "fogOut"
+	registerOutKey    = "device.registered"
+	schemaOutKey      = "schema.updated"
+	listThingsOutKey  = "device.list"
+	requestDataOutKey = "data.request"
 )
 
 // MsgPublisher handle messages received from a service
@@ -26,6 +27,7 @@ type Publisher interface {
 	SendRegisterDevice(network.RegisterResponseMsg) error
 	SendUpdatedSchema(thingID string) error
 	SendThings(things []*entities.Thing) error
+	SendRequestData(thingID string, sensorIds []int) error
 }
 
 // NewMsgPublisher constructs the MsgPublisher
@@ -66,4 +68,15 @@ func (mp *MsgPublisher) SendThings(things []*entities.Thing) error {
 	}
 
 	return mp.amqp.PublishPersistentMessage(exchangeFogOut, listThingsOutKey, msg)
+}
+
+// SendRequestData sends request data command
+func (mp *MsgPublisher) SendRequestData(thingID string, sensorIds []int) error {
+	resp := &network.RequestDataCommand{ID: thingID, SensorIds: sensorIds}
+	msg, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, requestDataOutKey, msg)
 }

--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -110,7 +110,10 @@ func (mc *MsgHandler) handleRequestData(body []byte, authorization string) error
 
 	mc.logger.Info("Request data command received")
 	mc.logger.Debug(authorization, requestDataReq)
-	// TODO: call request data interactor
+	err = mc.thingInteractor.RequestData(authorization, requestDataReq.ID, requestDataReq.SensorIds)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -12,6 +12,7 @@ type Interactor interface {
 	Register(authorization, id, name string) error
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
 	List(authorization string) error
+	RequestData(authorization, thingID string, sensorIds []int) error
 }
 
 // ThingInteractor represents the thing interactor capabilities, it's composed

--- a/pkg/thing/interactors/request_data.go
+++ b/pkg/thing/interactors/request_data.go
@@ -1,0 +1,83 @@
+package interactors
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+)
+
+type invalidSensorErr struct {
+	errors []error
+}
+
+func (ise *invalidSensorErr) Error() string {
+	msg := ""
+
+	for _, e := range ise.errors {
+		msg = msg + e.Error() + "\n"
+	}
+
+	return msg
+}
+
+// RequestData executes the use case operations to request data from the thing
+func (i *ThingInteractor) RequestData(authorization, thingID string, sensorIds []int) error {
+	if authorization == "" {
+		return errors.New("authorization key not provided")
+	}
+
+	thing, err := i.thingProxy.GetThing(authorization, thingID)
+	if err != nil {
+		i.logger.Error(err)
+		return err
+	}
+
+	if thing.Schema == nil {
+		i.logger.Error(fmt.Errorf("thing %s has no schema yet", thing.ID))
+		return err
+	}
+
+	err = validateSensors(sensorIds, thing.Schema)
+	if err != nil {
+		i.logger.Error(err)
+		return err
+	}
+
+	err = i.msgPublisher.SendRequestData(thingID, sensorIds)
+	if err != nil {
+		i.logger.Error(err)
+		return err
+	}
+
+	i.logger.Info("data request command successfully sent")
+	return nil
+}
+
+// validateSensors validates a slice of sensor ids against the thing's registered schema
+// that represents the sensors and actuators associated to it.
+func validateSensors(sensorIds []int, schema []entities.Schema) error {
+	var errs []error
+
+	for _, id := range sensorIds {
+		if !sensorExists(schema, id) {
+			errs = append(errs, fmt.Errorf("sensor %d isn't registered", id))
+		}
+	}
+
+	if len(errs) > 0 {
+		return &invalidSensorErr{errs}
+	}
+
+	return nil
+}
+
+func sensorExists(schema []entities.Schema, id int) bool {
+	for _, s := range schema {
+		if s.SensorID == id {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/thing/interactors/request_data_test.go
+++ b/pkg/thing/interactors/request_data_test.go
@@ -1,0 +1,186 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type GetDataTestCase struct {
+	name                        string
+	authorization               string
+	thingID                     string
+	sensorIds                   []int
+	expectedThing               *entities.Thing
+	expectedThingError          error
+	expectedRequestDataResponse error
+	fakeLogger                  *mocks.FakeLogger
+	fakeThingProxy              *mocks.FakeThingProxy
+	fakePublisher               *mocks.FakePublisher
+}
+
+var gdCases = []GetDataTestCase{
+	{
+		"authorization key not provided",
+		"",
+		"",
+		nil,
+		nil,
+		nil,
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"failed to authenticate with provided key",
+		"authorization-key",
+		"fc3fcf912d0c290a",
+		nil,
+		nil,
+		errors.New("Invalid credentials"),
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"thing doesn't exists on thing's service",
+		"authorization-key",
+		"fc3fcf912d0c290a",
+		nil,
+		nil,
+		errors.New("Thing fc3fcf912d0c290a not found"),
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"thing successfully obtained from the thing's service",
+		"authorization-key",
+		"fc3fcf912d0c290a",
+		[]int{2},
+		&entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+			Schema: []entities.Schema{
+				{
+					SensorID:  2,
+					ValueType: 3,
+					Unit:      0,
+					TypeID:    65521,
+					Name:      "Test",
+				},
+			},
+		},
+		nil,
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"thing hasn't schema for the requested sensor",
+		"authorization-key",
+		"fc3fcf912d0c290a",
+		[]int{1}, // the sensor id 1 can't be mapped to thing's schema
+		&entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+			Schema: []entities.Schema{
+				{
+					SensorID:  0,
+					ValueType: 3,
+					Unit:      0,
+					TypeID:    65521,
+					Name:      "Test",
+				},
+			},
+		},
+		nil,
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"failed to send quest data command to message queue",
+		"authorization key",
+		"fc3fcf912d0c290a",
+		[]int{1},
+		&entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+			Schema: []entities.Schema{
+				{
+					SensorID:  1,
+					ValueType: 3,
+					Unit:      0,
+					TypeID:    65521,
+					Name:      "Test",
+				},
+			},
+		},
+		nil,
+		errors.New("Failed to send request data message"),
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"request data command successfully sent",
+		"authorization key",
+		"fc3fcf912d0c290a",
+		[]int{1},
+		&entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+			Schema: []entities.Schema{
+				{
+					SensorID:  1,
+					ValueType: 3,
+					Unit:      0,
+					TypeID:    65521,
+					Name:      "Test",
+				},
+			},
+		},
+		nil,
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+}
+
+func TestGetData(t *testing.T) {
+	for _, tc := range gdCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fakeThingProxy.
+				On("GetThing", tc.authorization, tc.thingID).
+				Return(tc.expectedThing, tc.expectedThingError).
+				Maybe()
+			tc.fakePublisher.
+				On("SendRequestData", tc.thingID, tc.sensorIds).
+				Return(tc.expectedRequestDataResponse).
+				Maybe()
+		})
+
+		thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, nil)
+		err := thingInteractor.RequestData(tc.authorization, tc.thingID, tc.sensorIds)
+		if tc.authorization == "" {
+			assert.EqualError(t, err, "authorization key not provided")
+		}
+
+		tc.fakeThingProxy.AssertExpectations(t)
+		tc.fakePublisher.AssertExpectations(t)
+	}
+}

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -31,3 +31,9 @@ func (fp *FakePublisher) SendThings(things []*entities.Thing) error {
 	args := fp.Called(things)
 	return args.Error(0)
 }
+
+// SendRequestData provides a mock function to send a request data command
+func (fp *FakePublisher) SendRequestData(thingID string, sensorIds []int) error {
+	args := fp.Called(thingID, sensorIds)
+	return args.Error(0)
+}

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -1,7 +1,6 @@
 package mocks
 
 import (
-	"github.com/CESARBR/knot-babeltower/pkg/thing/delivery/http"
 	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 	"github.com/stretchr/testify/mock"
 )
@@ -24,9 +23,10 @@ func (ftp *FakeThingProxy) UpdateSchema(authorization, thingID string, schema []
 	return ret.Error(0)
 }
 
-// Get provides a mock function to receive a thing from the thing's service
-func (ftp *FakeThingProxy) Get(authorization, thingID string) (*http.ThingProxyRepr, error) {
-	return nil, nil
+// GetThing provides a mock function to receive a thing from the thing's service
+func (ftp *FakeThingProxy) GetThing(authorization, thingID string) (*entities.Thing, error) {
+	args := ftp.Called(authorization, thingID)
+	return args.Get(0).(*entities.Thing), args.Error(1)
 }
 
 // List provides a mock function to list things from the thing's service


### PR DESCRIPTION
What does this implement/fix? 
---------------------------------------------------
In the KNoT platform, devices can receive commands that gather the current state of registered sensors and actuators and the returned state can be used by the applications for any purpose. With this in mind, this pull request adds the necessary code to accomplish that.

Closes #8 