### PR TITLE
Add device authentication operation

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -42,3 +42,9 @@ type RequestDataCommand struct {
 	ID        string `json:"id"`
 	SensorIds []int  `json:"sensorIds"`
 }
+
+// AuthThingCommand represents the auth device command
+type AuthThingCommand struct {
+	ID    string `json:"id"`
+	Token string `json:"token"`
+}

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -48,3 +48,9 @@ type AuthThingCommand struct {
 	ID    string `json:"id"`
 	Token string `json:"token"`
 }
+
+// AuthThingResponse represents the auth device command response
+type AuthThingResponse struct {
+	ID     string  `json:"id"`
+	ErrMsg *string `json:"error"`
+}

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -13,6 +13,7 @@ const (
 	registerOutKey    = "device.registered"
 	schemaOutKey      = "schema.updated"
 	listThingsOutKey  = "device.list"
+	authDeviceOutKey  = "device.auth"
 	requestDataOutKey = "data.request"
 )
 
@@ -27,6 +28,7 @@ type ClientPublisher interface {
 	SendRegisterDevice(network.RegisterResponseMsg) error
 	SendUpdatedSchema(thingID string) error
 	SendThings(things []*entities.Thing) error
+	SendAuthStatus(thingID string, errMsg *string) error
 	SendRequestData(thingID string, sensorIds []int) error
 }
 
@@ -68,6 +70,17 @@ func (mp *msgClientPublisher) SendThings(things []*entities.Thing) error {
 	}
 
 	return mp.amqp.PublishPersistentMessage(exchangeFogOut, listThingsOutKey, msg)
+}
+
+// SendAuthStatus sends the auth thing status response
+func (mp *msgClientPublisher) SendAuthStatus(thingID string, errMsg *string) error {
+	resp := &network.AuthThingResponse{ID: thingID, ErrMsg: errMsg}
+	msg, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, authDeviceOutKey, msg)
 }
 
 // SendRequestData sends request data command

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -85,11 +85,6 @@ type RequestInfo struct {
 }
 
 type errorConflict struct{ error }
-type errorForbidden struct{ error }
-
-func (err errorForbidden) Error() string {
-	return "Error forbidden"
-}
 
 func (err errorConflict) Error() string {
 	return "Error conflict"
@@ -103,7 +98,7 @@ func (p proxy) mapErrorFromStatusCode(code int) error {
 		case http.StatusConflict:
 			err = errorConflict{}
 		case http.StatusForbidden:
-			err = errorForbidden{}
+			err = entities.ErrThingForbidden{}
 		}
 	}
 	return err

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -152,10 +152,15 @@ func (p proxy) Create(id, name, authorization string) (idGenerated string, err e
 		return "", err
 	}
 
+	err = p.mapErrorFromStatusCode(resp.StatusCode)
+	if err != nil {
+		p.logger.Error(err)
+		return "", err
+	}
+
 	locationHeader := resp.Header.Get("Location")
-	fmt.Print(locationHeader)
 	thingID := locationHeader[len("/things/"):] // get substring after "/things/"
-	return thingID, p.mapErrorFromStatusCode(resp.StatusCode)
+	return thingID, nil
 }
 
 // UpdateSchema receives the thing's ID and schema and send a HTTP request to

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -48,15 +48,6 @@ type pageFetchInput struct {
 	Things []*ThingProxyRepr `json:"things"`
 }
 
-// ErrThingNotFound represents the error when the schema has a invalid format
-type ErrThingNotFound struct {
-	ID string
-}
-
-func (etnf *ErrThingNotFound) Error() string {
-	return fmt.Sprintf("Thing %s not found", etnf.ID)
-}
-
 func (p proxy) getRemoteThingRepr(id, name string, schemaList []entities.Schema) ThingProxyRepr {
 	return ThingProxyRepr{
 		Name: name,
@@ -273,5 +264,5 @@ func (p proxy) GetThing(authorization, ID string) (*entities.Thing, error) {
 		}
 	}
 
-	return nil, &ErrThingNotFound{ID}
+	return nil, &entities.ErrThingNotFound{ID: ID}
 }

--- a/pkg/thing/entities/err_thing_forbidden.go
+++ b/pkg/thing/entities/err_thing_forbidden.go
@@ -1,0 +1,8 @@
+package entities
+
+// ErrThingForbidden represents the error when thing cannot be authenticated
+type ErrThingForbidden struct{}
+
+func (etf ErrThingForbidden) Error() string {
+	return "Forbidden to authenticate thing"
+}

--- a/pkg/thing/entities/err_thing_not_found.go
+++ b/pkg/thing/entities/err_thing_not_found.go
@@ -1,0 +1,12 @@
+package entities
+
+import "fmt"
+
+// ErrThingNotFound represents the error when the schema has a invalid format
+type ErrThingNotFound struct {
+	ID string
+}
+
+func (etnf ErrThingNotFound) Error() string {
+	return fmt.Sprintf("Thing %s not found", etnf.ID)
+}

--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -103,6 +103,21 @@ func (mc *MsgHandler) handleListDevices(authorization string) error {
 	return mc.thingInteractor.List(authorization)
 }
 
+func (mc *MsgHandler) handleAuthDevice(body []byte, authorization string) error {
+	var authThingReq network.AuthThingCommand
+	err := json.Unmarshal(body, &authThingReq)
+	if err != nil {
+		mc.logger.Error(err)
+		return err
+	}
+
+	mc.logger.Info("Auth device command received")
+	mc.logger.Debug(authorization, authThingReq)
+	// TODO: call auth device interactor
+
+	return nil
+}
+
 func (mc *MsgHandler) handleRequestData(body []byte, authorization string) error {
 	var requestDataReq network.RequestDataCommand
 	err := json.Unmarshal(body, &requestDataReq)
@@ -142,6 +157,12 @@ func (mc *MsgHandler) onMsgReceived(msgChan chan network.InMsg) {
 		case "device.cmd.list":
 			mc.logger.Info("List things request received")
 			err := mc.handleListDevices(authorizationHeader.(string))
+			if err != nil {
+				mc.logger.Error(err)
+				continue
+			}
+		case "device.cmd.auth":
+			err := mc.handleAuthDevice(msg.Body, authorizationHeader.(string))
 			if err != nil {
 				mc.logger.Error(err)
 				continue

--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -113,9 +113,7 @@ func (mc *MsgHandler) handleAuthDevice(body []byte, authorization string) error 
 
 	mc.logger.Info("Auth device command received")
 	mc.logger.Debug(authorization, authThingReq)
-	// TODO: call auth device interactor
-
-	return nil
+	return mc.thingInteractor.Auth(authorization, authThingReq.ID, authThingReq.Token)
 }
 
 func (mc *MsgHandler) handleRequestData(body []byte, authorization string) error {

--- a/pkg/thing/interactors/auth_thing.go
+++ b/pkg/thing/interactors/auth_thing.go
@@ -1,0 +1,38 @@
+package interactors
+
+import (
+	"errors"
+)
+
+// Auth is responsible to implement the thing's authentication use case
+func (i *ThingInteractor) Auth(authorization, id, token string) error {
+
+	if authorization == "" {
+		return errors.New("authorization key not provided")
+	}
+
+	if id == "" {
+		return errors.New("thing's id not provided")
+	}
+
+	if token == "" {
+		return errors.New("thing's token not provided")
+	}
+
+	_, err := i.thingProxy.GetThing(authorization, id)
+	if err != nil {
+		i.logger.Error(err)
+		msg := err.Error()
+		err = i.clientPublisher.SendAuthStatus(id, &msg)
+		return err
+	}
+
+	err = i.clientPublisher.SendAuthStatus(id, nil)
+	if err != nil {
+		i.logger.Error(err)
+		return err
+	}
+
+	i.logger.Info("authentication status sucessfully sent")
+	return nil
+}

--- a/pkg/thing/interactors/auth_thing_test.go
+++ b/pkg/thing/interactors/auth_thing_test.go
@@ -1,0 +1,162 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type AuthThingTestCase struct {
+	name           string
+	authParam      string
+	idParam        string
+	tokenParam     string
+	expectedErr    error
+	fakeLogger     *mocks.FakeLogger
+	fakeThingProxy *mocks.FakeThingProxy
+	fakePublisher  *mocks.FakePublisher
+	fakeConnector  *mocks.FakeConnector
+}
+
+var errMsg1 = "Thing 6c0dcd9833b595f9 not found"
+var errMsg2 = "Forbidden to authenticate thing"
+
+var atCases = []AuthThingTestCase{
+	{
+		"authorization key not provided",
+		"",
+		"8380ba096a091fb9",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		errors.New("authorization key not provided"),
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+	},
+	{
+		"thing's id not provided",
+		"authorization-token",
+		"",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		errors.New("thing's id not provided"),
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+	},
+	{
+		"thing's token not provided",
+		"authorization-token",
+		"8380ba096a091fb9",
+		"",
+		errors.New("thing's token not provided"),
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+	},
+	{
+		"thing 6c0dcd9833b595f9 not found",
+		"authorization-token",
+		"6c0dcd9833b595f9",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		entities.ErrThingNotFound{ID: "6c0dcd9833b595f9"},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: entities.ErrThingNotFound{ID: "6c0dcd9833b595f9"}},
+		&mocks.FakePublisher{ErrMsg: &errMsg1},
+		&mocks.FakeConnector{},
+	},
+	{
+		"forbidden to authenticate the thing",
+		"invalid-authorization-token",
+		"8380ba096a091fb9",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		&entities.ErrThingForbidden{},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: &entities.ErrThingForbidden{}},
+		&mocks.FakePublisher{ErrMsg: &errMsg2},
+		&mocks.FakeConnector{},
+	},
+	{
+		"allowed to authenticate the thing",
+		"authorization-token",
+		"8380ba096a091fb9",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+		}},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+	},
+	{
+		"failed to send the authenticate response",
+		"authorization-token",
+		"8380ba096a091fb9",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		errors.New("failed to send authenticate response"),
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+		}},
+		&mocks.FakePublisher{SendError: errors.New("failed to send authenticate response")},
+		&mocks.FakeConnector{},
+	},
+	{
+		"authenticate response successfully sent",
+		"authorization-token",
+		"8380ba096a091fb9",
+		"b2773648-055e-4b10-af53-df82080c38b3",
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:    "fc3fcf912d0c290a",
+			Token: "token",
+			Name:  "thing",
+		}},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+	},
+}
+
+func TestAuthThing(t *testing.T) {
+	for _, tc := range atCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fakeThingProxy.
+				On("GetThing", tc.authParam, tc.idParam).
+				Return(tc.fakeThingProxy.Thing, tc.fakeThingProxy.ReturnErr).
+				Maybe()
+			tc.fakePublisher.
+				On("SendAuthStatus", tc.idParam, tc.fakePublisher.ErrMsg).
+				Return(tc.fakeConnector.SendError).
+				Maybe()
+
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, tc.fakeConnector)
+			err := thingInteractor.Auth(tc.authParam, tc.idParam, tc.tokenParam)
+
+			if tc.authParam == "" {
+				msg := tc.expectedErr.Error()
+				assert.EqualError(t, err, msg)
+			}
+			if tc.idParam == "" {
+				msg := tc.expectedErr.Error()
+				assert.EqualError(t, err, msg)
+			}
+			if tc.tokenParam == "" {
+				msg := tc.expectedErr.Error()
+				assert.EqualError(t, err, msg)
+			}
+
+			tc.fakeThingProxy.AssertExpectations(t)
+			tc.fakePublisher.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -13,6 +13,7 @@ type Interactor interface {
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
 	List(authorization string) error
 	RequestData(authorization, thingID string, sensorIds []int) error
+	Auth(authorization, id, token string) error
 }
 
 // ThingInteractor represents the thing interactor capabilities, it's composed

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -12,6 +12,7 @@ type FakePublisher struct {
 	ReturnErr error
 	SendError error
 	Token     string
+	ErrMsg    *string
 }
 
 // SendRegisterDevice provides a mock function to send a register device response
@@ -29,6 +30,12 @@ func (fp *FakePublisher) SendUpdatedSchema(thingID string) error {
 // SendThings provides a mock function to send a list things response
 func (fp *FakePublisher) SendThings(things []*entities.Thing) error {
 	args := fp.Called(things)
+	return args.Error(0)
+}
+
+// SendAuthStatus provides a mock function to send auth thing command response
+func (fp *FakePublisher) SendAuthStatus(thingID string, errMsg *string) error {
+	args := fp.Called(thingID, errMsg)
 	return args.Error(0)
 }
 

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -9,6 +9,7 @@ import (
 type FakeThingProxy struct {
 	mock.Mock
 	ReturnErr error
+	Thing     *entities.Thing
 }
 
 // Create provides a mock function to create a thing on the thing's seervice


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch implements the device auth command operation in the client side.

Where has this been tested?
---------------------------

**Operating System/Platform:** Ubuntu 18.04.4

**Go Version:** 1.13.6
