### PR TITLE
Add unregister device operation

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -26,6 +26,12 @@ type RegisterResponseMsg struct {
 	Error *string `json:"error"`
 }
 
+// UnregisterResponseMsg represents the outgoing unregister device response message
+type UnregisterResponseMsg struct {
+	ID    string  `json:"id"`
+	Error *string `json:"error"`
+}
+
 // UpdateSchemaRequest represents the update schema request message
 type UpdateSchemaRequest struct {
 	ID     string            `json:"id"`

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -2,7 +2,7 @@ package network
 
 import "github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 
-// RegisterRequestMsg is received to register a device
+// RegisterRequestMsg represents the incoming register device request message
 type RegisterRequestMsg struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -19,7 +19,7 @@ type UpdateSchemaRequestMsg struct {
 	Schema []entities.Schema `json:"schema,omitempty"`
 }
 
-// RegisterResponseMsg is sent when receive a register request
+// RegisterResponseMsg represents the outgoing register device response message
 type RegisterResponseMsg struct {
 	ID    string  `json:"id"`
 	Token string  `json:"token"`

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -8,6 +8,11 @@ type RegisterRequestMsg struct {
 	Name string `json:"name"`
 }
 
+// UnregisterRequestMsg represents the incoming unregister device request message
+type UnregisterRequestMsg struct {
+	ID string `json:"id"`
+}
+
 // UpdateSchemaRequestMsg represents the update schema request message
 type UpdateSchemaRequestMsg struct {
 	ID     string            `json:"id"`

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -26,7 +26,7 @@ type msgClientPublisher struct {
 
 // ClientPublisher is the interface with methods that the publisher should have
 type ClientPublisher interface {
-	SendRegisterDevice(network.RegisterResponseMsg) error
+	SendRegisteredDevice(network.RegisterResponseMsg) error
 	SendUnregisteredDevice(thingID string, errMsg *string) error
 	SendUpdatedSchema(thingID string) error
 	SendThings(things []*entities.Thing) error
@@ -40,9 +40,8 @@ func NewMsgClientPublisher(logger logging.Logger, amqp *network.Amqp) ClientPubl
 }
 
 // SendRegisterDevice publishes the registered device's credentials to the device registration queue
-func (mp *msgClientPublisher) SendRegisterDevice(msg network.RegisterResponseMsg) error {
-	mp.logger.Debug("Sending register message")
-
+func (mp *msgClientPublisher) SendRegisteredDevice(msg network.RegisterResponseMsg) error {
+	mp.logger.Debug("Sending registered message")
 	jsonMsg, err := json.Marshal(msg)
 	if err != nil {
 		mp.logger.Error(err)

--- a/pkg/thing/delivery/amqp/connector.go
+++ b/pkg/thing/delivery/amqp/connector.go
@@ -32,7 +32,7 @@ func NewMsgConnectorPublisher(logger logging.Logger, amqp *network.Amqp) Connect
 	return &msgConnectorPublisher{logger, amqp}
 }
 
-// SendRegisterDevice sends a registered message
+// SendRegisterDevice sends a register message
 func (mp *msgConnectorPublisher) SendRegisterDevice(id string, name string) error {
 	mp.logger.Debug("Sending register message")
 

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -17,7 +17,7 @@ type ThingProxy interface {
 	Create(id, name, authorization string) (idGenerated string, err error)
 	UpdateSchema(authorization, ID string, schemaList []entities.Schema) error
 	List(authorization string) (things []*entities.Thing, err error)
-	GetThing(authorization, ID string) (*entities.Thing, error)
+	Get(authorization, ID string) (*entities.Thing, error)
 	Remove(authorization, ID string) error
 }
 
@@ -168,7 +168,7 @@ func (p proxy) Create(id, name, authorization string) (idGenerated string, err e
 // UpdateSchema receives the thing's ID and schema and send a HTTP request to
 // the thing's service in order to update it with the schema.
 func (p proxy) UpdateSchema(authorization, ID string, schemaList []entities.Schema) error {
-	t, err := p.GetThing(authorization, ID)
+	t, err := p.Get(authorization, ID)
 	if err != nil {
 		return err
 	}
@@ -251,8 +251,8 @@ func (p proxy) getPaginatedThings(authorization string) ([]*ThingProxyRepr, erro
 	return things, nil
 }
 
-// GetThing list the things registered on thing's service
-func (p proxy) GetThing(authorization, ID string) (*entities.Thing, error) {
+// Get list the things registered on thing's service
+func (p proxy) Get(authorization, ID string) (*entities.Thing, error) {
 	things, err := p.getPaginatedThings(authorization)
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func (p proxy) GetThing(authorization, ID string) (*entities.Thing, error) {
 
 // Remove removes the indicated thing from the thing's service
 func (p proxy) Remove(authorization, ID string) error {
-	t, err := p.GetThing(authorization, ID)
+	t, err := p.Get(authorization, ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -70,13 +70,13 @@ func (mc *MsgHandler) subscribeToMessages(msgChan chan network.InMsg) error {
 }
 
 func (mc *MsgHandler) handleRegisterMsg(body []byte, authorizationHeader string) error {
-	msgParsed := network.RegisterRequestMsg{}
-	err := json.Unmarshal(body, &msgParsed)
+	msg := network.RegisterRequestMsg{}
+	err := json.Unmarshal(body, &msg)
 	if err != nil {
 		return err
 	}
 
-	return mc.thingInteractor.Register(authorizationHeader, msgParsed.ID, msgParsed.Name)
+	return mc.thingInteractor.Register(authorizationHeader, msg.ID, msg.Name)
 }
 
 func (mc *MsgHandler) handleUnregisterMsg(body []byte, authorizationHeader string) error {

--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -79,6 +79,17 @@ func (mc *MsgHandler) handleRegisterMsg(body []byte, authorizationHeader string)
 	return mc.thingInteractor.Register(authorizationHeader, msgParsed.ID, msgParsed.Name)
 }
 
+func (mc *MsgHandler) handleUnregisterMsg(body []byte, authorizationHeader string) error {
+	msg := network.UnregisterRequestMsg{}
+	err := json.Unmarshal(body, &msg)
+	if err != nil {
+		return err
+	}
+
+	// TODO: call unregister device interactor
+	return nil
+}
+
 func (mc *MsgHandler) handleUpdateSchemaMsg(body []byte, authorizationHeader string) error {
 	var updateSchemaReq network.UpdateSchemaRequest
 	err := json.Unmarshal(body, &updateSchemaReq)
@@ -152,6 +163,12 @@ func (mc *MsgHandler) onMsgReceived(msgChan chan network.InMsg) {
 		case "device.registered":
 			// Ignore message
 			continue
+		case "device.unregister":
+			err := mc.handleUnregisterMsg(msg.Body, authorizationHeader.(string))
+			if err != nil {
+				mc.logger.Error(err)
+				continue
+			}
 		case "device.cmd.list":
 			mc.logger.Info("List things request received")
 			err := mc.handleListDevices(authorizationHeader.(string))

--- a/pkg/thing/handler/amqp/msg_handler.go
+++ b/pkg/thing/handler/amqp/msg_handler.go
@@ -86,8 +86,7 @@ func (mc *MsgHandler) handleUnregisterMsg(body []byte, authorizationHeader strin
 		return err
 	}
 
-	// TODO: call unregister device interactor
-	return nil
+	return mc.thingInteractor.Unregister(authorizationHeader, msg.ID)
 }
 
 func (mc *MsgHandler) handleUpdateSchemaMsg(body []byte, authorizationHeader string) error {

--- a/pkg/thing/interactors/auth_thing.go
+++ b/pkg/thing/interactors/auth_thing.go
@@ -19,7 +19,7 @@ func (i *ThingInteractor) Auth(authorization, id, token string) error {
 		return errors.New("thing's token not provided")
 	}
 
-	_, err := i.thingProxy.GetThing(authorization, id)
+	_, err := i.thingProxy.Get(authorization, id)
 	if err != nil {
 		i.logger.Error(err)
 		msg := err.Error()

--- a/pkg/thing/interactors/auth_thing_test.go
+++ b/pkg/thing/interactors/auth_thing_test.go
@@ -131,7 +131,7 @@ func TestAuthThing(t *testing.T) {
 	for _, tc := range atCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.fakeThingProxy.
-				On("GetThing", tc.authParam, tc.idParam).
+				On("Get", tc.authParam, tc.idParam).
 				Return(tc.fakeThingProxy.Thing, tc.fakeThingProxy.ReturnErr).
 				Maybe()
 			tc.fakePublisher.

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -10,6 +10,7 @@ import (
 // Interactor is an interface that defines the thing's use cases operations
 type Interactor interface {
 	Register(authorization, id, name string) error
+	Unregister(authorization, id string) error
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
 	List(authorization string) error
 	RequestData(authorization, thingID string, sensorIds []int) error

--- a/pkg/thing/interactors/register_thing.go
+++ b/pkg/thing/interactors/register_thing.go
@@ -15,10 +15,10 @@ type ErrorIDInvalid struct{}
 // ErrorNameNotFound is raised when Name is empty
 type ErrorNameNotFound struct{}
 
-// ErrorMissingArgument is raised there is some argument missing
+// ErrorMissingArgument is raised when there is some argument missing
 type ErrorMissingArgument struct{}
 
-// ErrorInvalidTypeArgument is raised when the type is the expected
+// ErrorInvalidTypeArgument is raised when the type is not the expected
 type ErrorInvalidTypeArgument struct{ msg string }
 
 func (err ErrorIDLenght) Error() string {

--- a/pkg/thing/interactors/register_thing.go
+++ b/pkg/thing/interactors/register_thing.go
@@ -52,7 +52,7 @@ func (i *ThingInteractor) reply(id, token string, err error) error {
 	}
 
 	response := network.RegisterResponseMsg{ID: id, Token: token, Error: errStr}
-	errPublish := i.clientPublisher.SendRegisterDevice(response)
+	errPublish := i.clientPublisher.SendRegisteredDevice(response)
 	if errPublish != nil {
 		i.logger.Error(errPublish)
 		return errPublish

--- a/pkg/thing/interactors/register_thing_test.go
+++ b/pkg/thing/interactors/register_thing_test.go
@@ -87,7 +87,7 @@ func TestRegisterThing(t *testing.T) {
 			}
 
 			msg := network.RegisterResponseMsg{ID: tc.thingID, Token: tc.fakePublisher.Token, Error: tmp}
-			tc.fakePublisher.On("SendRegisterDevice", msg).
+			tc.fakePublisher.On("SendRegisteredDevice", msg).
 				Return(tc.fakePublisher.ReturnErr)
 			tc.fakeThingProxy.On("Create", tc.thingID, tc.thingName, tc.authorization).
 				Return(tc.fakePublisher.Token, tc.fakeThingProxy.ReturnErr).Maybe()

--- a/pkg/thing/interactors/request_data.go
+++ b/pkg/thing/interactors/request_data.go
@@ -27,7 +27,7 @@ func (i *ThingInteractor) RequestData(authorization, thingID string, sensorIds [
 		return errors.New("authorization key not provided")
 	}
 
-	thing, err := i.thingProxy.GetThing(authorization, thingID)
+	thing, err := i.thingProxy.Get(authorization, thingID)
 	if err != nil {
 		i.logger.Error(err)
 		return err

--- a/pkg/thing/interactors/request_data_test.go
+++ b/pkg/thing/interactors/request_data_test.go
@@ -165,7 +165,7 @@ func TestGetData(t *testing.T) {
 	for _, tc := range gdCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.fakeThingProxy.
-				On("GetThing", tc.authorization, tc.thingID).
+				On("Get", tc.authorization, tc.thingID).
 				Return(tc.expectedThing, tc.expectedThingError).
 				Maybe()
 			tc.fakePublisher.

--- a/pkg/thing/interactors/unregister_thing.go
+++ b/pkg/thing/interactors/unregister_thing.go
@@ -1,0 +1,42 @@
+package interactors
+
+import (
+	"errors"
+)
+
+// Unregister runs the use case to remove a registered thing
+func (i *ThingInteractor) Unregister(authorization, id string) error {
+	i.logger.Debug("Executing unregister thing use case")
+
+	if authorization == "" {
+		return errors.New("authorization key not provided")
+	}
+
+	if id == "" {
+		return errors.New("thing's id not provided")
+	}
+
+	err := i.thingProxy.Remove(authorization, id)
+	if err != nil {
+		msg := err.Error()
+		sendErr := i.clientPublisher.SendUnregisteredDevice(id, &msg)
+		if sendErr != nil {
+			i.logger.Debug(msg)
+			return sendErr
+		}
+		return err
+	}
+
+	sendErr := i.connectorPublisher.SendUnregisterDevice(id)
+	if sendErr != nil {
+		// TODO handle error at sending unregister message to connector
+		i.logger.Error(sendErr)
+	}
+
+	sendErr = i.clientPublisher.SendUnregisteredDevice(id, nil)
+	if sendErr != nil {
+		return sendErr
+	}
+
+	return nil
+}

--- a/pkg/thing/interactors/unregister_thing_test.go
+++ b/pkg/thing/interactors/unregister_thing_test.go
@@ -1,0 +1,152 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type UnregisterThingTestCase struct {
+	name           string
+	authParam      string
+	idParam        string
+	fakeLogger     *mocks.FakeLogger
+	fakeThingProxy *mocks.FakeThingProxy
+	fakePublisher  *mocks.FakePublisher
+	fakeConnector  *mocks.FakeConnector
+	expectedErrMsg string
+}
+
+var unregisterErrMsg1 = "thing's id not found"
+var unregisterErrMsg2 = "unable to unregister thing"
+
+var unregisterAtCases = []UnregisterThingTestCase{
+	{
+		"authorization key not provided",
+		"",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+		"authorization key not provided",
+	},
+	{
+		"thing's id not provided",
+		"authorization-token",
+		"",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+		"thing's id not provided",
+	},
+	{
+		"thing's id not found",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errors.New("thing's id not found")},
+		&mocks.FakePublisher{ErrMsg: &unregisterErrMsg1},
+		&mocks.FakeConnector{},
+		"thing's id not found",
+	},
+	{
+		"unable to unregister thing",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errors.New("unable to unregister thing")},
+		&mocks.FakePublisher{ErrMsg: &unregisterErrMsg2},
+		&mocks.FakeConnector{},
+		"unable to unregister thing",
+	},
+	{
+		"failed to send unregister error response",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errors.New("unable to unregister thing")},
+		&mocks.FakePublisher{ErrMsg: &unregisterErrMsg2, SendError: errors.New("failed to send unregister response")},
+		&mocks.FakeConnector{},
+		"failed to send unregister response",
+	},
+	{
+		"failed to send unregister message to connector",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{SendError: errors.New("failed to send unregister message")},
+		"",
+	},
+	{
+		"failed to send unregister success response",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{SendError: errors.New("failed to send unregister response")},
+		&mocks.FakeConnector{},
+		"failed to send unregister response",
+	},
+	{
+		"allowed to unregister the thing",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+		"",
+	},
+	{
+		"unregister response successfully sent",
+		"authorization-token",
+		"thing-id",
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		&mocks.FakeConnector{},
+		"",
+	},
+}
+
+func TestUnregisterThing(t *testing.T) {
+	for _, tc := range unregisterAtCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fakeLogger.
+				On("Error", tc.fakeConnector.SendError).
+				Maybe()
+			tc.fakeThingProxy.
+				On("Remove", tc.authParam, tc.idParam).
+				Return(tc.fakeThingProxy.ReturnErr).
+				Maybe()
+			tc.fakePublisher.
+				On("SendUnregisteredDevice", tc.idParam, tc.fakePublisher.ErrMsg).
+				Return(tc.fakePublisher.SendError).
+				Maybe()
+			tc.fakeConnector.
+				On("SendUnregisterDevice", tc.idParam).
+				Return(tc.fakeConnector.SendError).
+				Maybe()
+
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, tc.fakeConnector)
+			err := thingInteractor.Unregister(tc.authParam, tc.idParam)
+
+			if err != nil {
+				assert.EqualError(t, err, tc.expectedErrMsg)
+			} else {
+				assert.EqualValues(t, tc.expectedErrMsg, "")
+			}
+
+			tc.fakeLogger.AssertExpectations(t)
+			tc.fakeThingProxy.AssertExpectations(t)
+			tc.fakePublisher.AssertExpectations(t)
+			tc.fakeConnector.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/thing/mocks/connector.go
+++ b/pkg/thing/mocks/connector.go
@@ -18,6 +18,12 @@ func (fc *FakeConnector) SendRegisterDevice(id, name string) (err error) {
 	return ret.Error(0)
 }
 
+// SendUnregisterDevice provides a mock function to send unregister device command to connector
+func (fc *FakeConnector) SendUnregisterDevice(id string) error {
+	ret := fc.Called(id)
+	return ret.Error(0)
+}
+
 // SendUpdateSchema provides a mock function to send an update schema command to connector
 func (fc *FakeConnector) SendUpdateSchema(id string, schemaList []entities.Schema) (err error) {
 	ret := fc.Called(id, schemaList)

--- a/pkg/thing/mocks/logger.go
+++ b/pkg/thing/mocks/logger.go
@@ -1,7 +1,11 @@
 package mocks
 
+import "github.com/stretchr/testify/mock"
+
 // FakeLogger represents a mocking type for the logging service
-type FakeLogger struct{}
+type FakeLogger struct{
+	mock.Mock
+}
 
 // Info provides a mock function for the debugging Info capability
 func (fl *FakeLogger) Info(...interface{}) {}

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -15,8 +15,8 @@ type FakePublisher struct {
 	ErrMsg    *string
 }
 
-// SendRegisterDevice provides a mock function to send a register device response
-func (fp *FakePublisher) SendRegisterDevice(msg network.RegisterResponseMsg) error {
+// SendRegisteredDevice provides a mock function to send a register device response
+func (fp *FakePublisher) SendRegisteredDevice(msg network.RegisterResponseMsg) error {
 	ret := fp.Called(msg)
 	return ret.Error(0)
 }

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -21,6 +21,12 @@ func (fp *FakePublisher) SendRegisterDevice(msg network.RegisterResponseMsg) err
 	return ret.Error(0)
 }
 
+// SendUnregisteredDevice provides a mock function to send an unregister device response
+func (fp *FakePublisher) SendUnregisteredDevice(thingID string, errMsg *string) error {
+	ret := fp.Called(thingID, errMsg)
+	return ret.Error(0)
+}
+
 // SendUpdatedSchema provides a mock function to send an update schema response
 func (fp *FakePublisher) SendUpdatedSchema(thingID string) error {
 	ret := fp.Called(thingID)

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -35,3 +35,9 @@ func (ftp *FakeThingProxy) List(authorization string) ([]*entities.Thing, error)
 	args := ftp.Called(authorization)
 	return args.Get(0).([]*entities.Thing), args.Error(1)
 }
+
+// Remove provides a mock function to remove a thing on the thing's service
+func (ftp *FakeThingProxy) Remove(authorization, thingID string) error {
+	ret := ftp.Called(authorization, thingID)
+	return ret.Error(0)
+}

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -12,7 +12,7 @@ type FakeThingProxy struct {
 	Thing     *entities.Thing
 }
 
-// Create provides a mock function to create a thing on the thing's seervice
+// Create provides a mock function to create a thing on the thing's service
 func (ftp *FakeThingProxy) Create(id, name, authorization string) (idGenerated string, err error) {
 	ret := ftp.Called(id, name, authorization)
 	return ret.String(0), ret.Error(1)

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -24,8 +24,8 @@ func (ftp *FakeThingProxy) UpdateSchema(authorization, thingID string, schema []
 	return ret.Error(0)
 }
 
-// GetThing provides a mock function to receive a thing from the thing's service
-func (ftp *FakeThingProxy) GetThing(authorization, thingID string) (*entities.Thing, error) {
+// Get provides a mock function to receive a thing from the thing's service
+func (ftp *FakeThingProxy) Get(authorization, thingID string) (*entities.Thing, error) {
 	args := ftp.Called(authorization, thingID)
 	return args.Get(0).(*entities.Thing), args.Error(1)
 }


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch implements the operation of unregister devices on babeltower service and repass this same command to connector.

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04.4

**Go Version:** 1.13.6
