### PR TITLE
Thing: Proxy: bug fix 

### DIFF
--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -151,6 +151,7 @@ func (p proxy) Create(id, name, authorization string) (idGenerated string, err e
 		p.logger.Error(err)
 		return "", err
 	}
+	defer resp.Body.Close()
 
 	err = p.mapErrorFromStatusCode(resp.StatusCode)
 	if err != nil {


### PR DESCRIPTION
**What does this PR introduce?**

This PR fixes a bug where the connection established by the client (babeltower) remained open even after reading the Body. In order to better understand the consequences of not closing a network connection with deferred `resp.Body.Close()`, one might find these useful :point_down: 
> **[1]** golang.org/pkg/net/http/#Client.Do
> **[2]** stackoverflow.com/questions/33238518/what-could-happen-if-i-dont-close-response-body-in-golang
> **[3]** stackoverflow.com/questions/18598780/is-resp-body-close-necessary-if-we-dont-read-anything-from-the-body

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Does this close any currently open issues?**
(Use the special github keywords to reference issues: https://help.github.com/en/articles/closing-issues-using-keywords)

Nope :grimacing: 

**Any relevant logs, error output, etc?**

Nope :smile: 

**Any additional comments?**

Nope :confetti_ball: 

**Where has this been tested?**

- Operating System/Platform: Linux 5.5.7-arch1-1 x86_64 GNU/Linux
- Go Version: go1.14 linux/amd64
