### PR TITLE
refactor: code style: Standardize identifier names and order of appearance

### DIFF
--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -24,76 +24,6 @@ type InMsg struct {
 	Body       []byte
 }
 
-func (a *Amqp) notifyWhenClosed(started chan bool) {
-	errReason := <-a.conn.NotifyClose(make(chan *amqp.Error))
-	a.logger.Infof("AMQP connection closed: %s", errReason)
-	started <- false
-	if errReason != nil {
-		err := backoff.Retry(a.connect, backoff.NewExponentialBackOff())
-		if err != nil {
-			a.logger.Error(err)
-			started <- false
-			return
-		}
-
-		go a.notifyWhenClosed(started)
-		started <- true
-	}
-}
-
-func (a *Amqp) connect() error {
-	conn, err := amqp.Dial(a.url)
-	if err != nil {
-		a.logger.Error(err)
-		return err
-	}
-
-	a.conn = conn
-
-	channel, err := a.conn.Channel()
-	if err != nil {
-		a.logger.Error(err)
-		return err
-	}
-
-	a.logger.Debug("AMQP handler connected")
-	a.channel = channel
-
-	return nil
-}
-
-func (a *Amqp) declareExchange(name string) error {
-	return a.channel.ExchangeDeclare(
-		name,
-		amqp.ExchangeTopic, // type
-		true,               // durable
-		false,              // delete when complete
-		false,              // internal
-		false,              // noWait
-		nil,                // arguments
-	)
-}
-
-func (a *Amqp) declareQueue(name string) error {
-	queue, err := a.channel.QueueDeclare(
-		name,
-		true,  // durable
-		false, // delete when unused
-		false, // exclusive
-		false, // noWait
-		nil,   // arguments
-	)
-
-	a.queue = &queue
-	return err
-}
-
-func convertDeliveryToInMsg(deliveries <-chan amqp.Delivery, outMsg chan InMsg) {
-	for d := range deliveries {
-		outMsg <- InMsg{d.Exchange, d.RoutingKey, d.Headers, d.Body}
-	}
-}
-
 // NewAmqp constructs the AMQP connection handler
 func NewAmqp(url string, logger logging.Logger) *Amqp {
 	return &Amqp{url, logger, nil, nil, nil}
@@ -110,6 +40,57 @@ func (a *Amqp) Start(started chan bool) {
 
 	go a.notifyWhenClosed(started)
 	started <- true
+}
+
+// Stop closes the connection started
+func (a *Amqp) Stop() {
+	if a.conn != nil && !a.conn.IsClosed() {
+		a.conn.Close()
+	}
+
+	if a.channel != nil {
+		a.channel.Close()
+	}
+
+	a.logger.Debug("AMQP handler stopped")
+}
+
+// PublishPersistentMessage sends a persistent message to RabbitMQ
+func (a *Amqp) PublishPersistentMessage(exchange, key string, body []byte) error {
+	err := a.channel.ExchangeDeclare(
+		exchange,
+		amqp.ExchangeTopic, // type
+		true,               // durable
+		false,              // delete when complete
+		false,              // internal
+		false,              // noWait
+		nil,                // arguments
+	)
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	err = a.channel.Publish(
+		exchange,
+		key,
+		false, // mandatory
+		false, // immediate
+		amqp.Publishing{
+			Headers:         amqp.Table{},
+			ContentType:     "text/plain",
+			ContentEncoding: "",
+			Body:            body,
+			DeliveryMode:    amqp.Persistent,
+			Priority:        0,
+		},
+	)
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	return nil
 }
 
 // OnMessage receive messages and put them on channel
@@ -157,10 +138,47 @@ func (a *Amqp) OnMessage(msgChan chan InMsg, queueName, exchangeName, key string
 	return nil
 }
 
-// PublishPersistentMessage sends a persistent message to RabbitMQ
-func (a *Amqp) PublishPersistentMessage(exchange, key string, body []byte) error {
-	err := a.channel.ExchangeDeclare(
-		exchange,
+func (a *Amqp) connect() error {
+	conn, err := amqp.Dial(a.url)
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	a.conn = conn
+
+	channel, err := a.conn.Channel()
+	if err != nil {
+		a.logger.Error(err)
+		return err
+	}
+
+	a.logger.Debug("AMQP handler connected")
+	a.channel = channel
+
+	return nil
+}
+
+func (a *Amqp) notifyWhenClosed(started chan bool) {
+	errReason := <-a.conn.NotifyClose(make(chan *amqp.Error))
+	a.logger.Infof("AMQP connection closed: %s", errReason)
+	started <- false
+	if errReason != nil {
+		err := backoff.Retry(a.connect, backoff.NewExponentialBackOff())
+		if err != nil {
+			a.logger.Error(err)
+			started <- false
+			return
+		}
+
+		go a.notifyWhenClosed(started)
+		started <- true
+	}
+}
+
+func (a *Amqp) declareExchange(name string) error {
+	return a.channel.ExchangeDeclare(
+		name,
 		amqp.ExchangeTopic, // type
 		true,               // durable
 		false,              // delete when complete
@@ -168,42 +186,24 @@ func (a *Amqp) PublishPersistentMessage(exchange, key string, body []byte) error
 		false,              // noWait
 		nil,                // arguments
 	)
-	if err != nil {
-		a.logger.Error(err)
-		return err
-	}
-
-	err = a.channel.Publish(
-		exchange,
-		key,
-		false, // mandatory
-		false, // immediate
-		amqp.Publishing{
-			Headers:         amqp.Table{},
-			ContentType:     "text/plain",
-			ContentEncoding: "",
-			Body:            body,
-			DeliveryMode:    amqp.Persistent,
-			Priority:        0,
-		},
-	)
-	if err != nil {
-		a.logger.Error(err)
-		return err
-	}
-
-	return nil
 }
 
-// Stop closes the connection started
-func (a *Amqp) Stop() {
-	if a.conn != nil && !a.conn.IsClosed() {
-		a.conn.Close()
-	}
+func (a *Amqp) declareQueue(name string) error {
+	queue, err := a.channel.QueueDeclare(
+		name,
+		true,  // durable
+		false, // delete when unused
+		false, // exclusive
+		false, // noWait
+		nil,   // arguments
+	)
 
-	if a.channel != nil {
-		a.channel.Close()
-	}
+	a.queue = &queue
+	return err
+}
 
-	a.logger.Debug("AMQP handler stopped")
+func convertDeliveryToInMsg(deliveries <-chan amqp.Delivery, outMsg chan InMsg) {
+	for d := range deliveries {
+		outMsg <- InMsg{d.Exchange, d.RoutingKey, d.Headers, d.Body}
+	}
 }

--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -57,15 +57,7 @@ func (a *Amqp) Stop() {
 
 // PublishPersistentMessage sends a persistent message to RabbitMQ
 func (a *Amqp) PublishPersistentMessage(exchange, key string, body []byte) error {
-	err := a.channel.ExchangeDeclare(
-		exchange,
-		amqp.ExchangeTopic, // type
-		true,               // durable
-		false,              // delete when complete
-		false,              // internal
-		false,              // noWait
-		nil,                // arguments
-	)
+	err := a.declareExchange(exchange)
 	if err != nil {
 		a.logger.Error(err)
 		return err

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -2,66 +2,60 @@ package network
 
 import "github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 
-// RegisterRequestMsg represents the incoming register device request message
-type RegisterRequestMsg struct {
+// DeviceRegisterRequest represents the incoming register device request message
+type DeviceRegisterRequest struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
 
-// UnregisterRequestMsg represents the incoming unregister device request message
-type UnregisterRequestMsg struct {
-	ID string `json:"id"`
-}
-
-// UpdateSchemaRequestMsg represents the update schema request message
-type UpdateSchemaRequestMsg struct {
-	ID     string            `json:"id"`
-	Schema []entities.Schema `json:"schema,omitempty"`
-}
-
-// RegisterResponseMsg represents the outgoing register device response message
-type RegisterResponseMsg struct {
+// DeviceRegisteredResponse represents the outgoing register device response message
+type DeviceRegisteredResponse struct {
 	ID    string  `json:"id"`
 	Token string  `json:"token"`
 	Error *string `json:"error"`
 }
 
-// UnregisterResponseMsg represents the outgoing unregister device response message
-type UnregisterResponseMsg struct {
+// DeviceUnregisterRequest represents the incoming unregister device request message
+type DeviceUnregisterRequest struct {
+	ID string `json:"id"`
+}
+
+// DeviceUnregisteredResponse represents the outgoing unregister device response message
+type DeviceUnregisteredResponse struct {
 	ID    string  `json:"id"`
 	Error *string `json:"error"`
 }
 
-// UpdateSchemaRequest represents the update schema request message
-type UpdateSchemaRequest struct {
+// SchemaUpdateRequest represents the incoming update schema request message
+type SchemaUpdateRequest struct {
 	ID     string            `json:"id"`
 	Schema []entities.Schema `json:"schema,omitempty"`
 }
 
-// UpdatedSchemaResponse represents the update schema response message
-type UpdatedSchemaResponse struct {
+// SchemaUpdatedResponse represents the outgoing update schema response message
+type SchemaUpdatedResponse struct {
 	ID string `json:"id"`
 }
 
-// ListThingsResponse represents the list things response
-type ListThingsResponse struct {
-	Things []*entities.Thing `json:"things"`
-}
-
-// RequestDataCommand represents the request data command
-type RequestDataCommand struct {
-	ID        string `json:"id"`
-	SensorIds []int  `json:"sensorIds"`
-}
-
-// AuthThingCommand represents the auth device command
-type AuthThingCommand struct {
+// DeviceAuthRequest represents the incoming auth device command
+type DeviceAuthRequest struct {
 	ID    string `json:"id"`
 	Token string `json:"token"`
 }
 
-// AuthThingResponse represents the auth device command response
-type AuthThingResponse struct {
+// DeviceAuthResponse represents the outgoing auth device command response
+type DeviceAuthResponse struct {
 	ID     string  `json:"id"`
 	ErrMsg *string `json:"error"`
+}
+
+// DeviceListResponse represents the outgoing list devices command response
+type DeviceListResponse struct {
+	Things []*entities.Thing `json:"things"`
+}
+
+// DataRequest represents the incoming request data command
+type DataRequest struct {
+	ID        string `json:"id"`
+	SensorIds []int  `json:"sensorIds"`
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -15,17 +15,17 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Health represents the service's health status
-type Health struct {
-	Status string `json:"status"`
-}
-
 // Server represents the HTTP server
 type Server struct {
 	port           int
 	logger         logging.Logger
 	userController *controllers.UserController
 	srv            *http.Server
+}
+
+// Health represents the service's health status
+type Health struct {
+	Status string `json:"status"`
 }
 
 // NewServer creates a new server instance
@@ -74,13 +74,6 @@ func (s *Server) createRouters() *mux.Router {
 	return r
 }
 
-func (s *Server) logRequest(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		s.logger.Infof("%s %s %s\n", r.RemoteAddr, r.Method, r.URL)
-		handler.ServeHTTP(w, r)
-	})
-}
-
 // Healthcheck godoc
 // @Summary Verify the service health
 // @Produce json
@@ -94,4 +87,11 @@ func (s *Server) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.logger.Errorf("Error sending response, %s\n", err)
 	}
+}
+
+func (s *Server) logRequest(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.logger.Infof("%s %s %s\n", r.RemoteAddr, r.Method, r.URL)
+		handler.ServeHTTP(w, r)
+	})
 }

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -21,7 +21,7 @@ func NewThingController(logger logging.Logger, thingInteractor interactors.Inter
 
 // Register handles the register device request and execute its use case
 func (mc *ThingController) Register(body []byte, authorizationHeader string) error {
-	msg := network.RegisterRequestMsg{}
+	msg := network.DeviceRegisterRequest{}
 	err := json.Unmarshal(body, &msg)
 	if err != nil {
 		return err
@@ -32,7 +32,7 @@ func (mc *ThingController) Register(body []byte, authorizationHeader string) err
 
 // Unregister handles the unregister device request and execute its use case
 func (mc *ThingController) Unregister(body []byte, authorizationHeader string) error {
-	msg := network.UnregisterRequestMsg{}
+	msg := network.DeviceUnregisterRequest{}
 	err := json.Unmarshal(body, &msg)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (mc *ThingController) Unregister(body []byte, authorizationHeader string) e
 
 // UpdateSchema handles the update schema request and execute its use case
 func (mc *ThingController) UpdateSchema(body []byte, authorizationHeader string) error {
-	var updateSchemaReq network.UpdateSchemaRequest
+	var updateSchemaReq network.SchemaUpdateRequest
 	err := json.Unmarshal(body, &updateSchemaReq)
 	if err != nil {
 		mc.logger.Error(err)
@@ -69,7 +69,7 @@ func (mc *ThingController) ListDevices(authorization string) error {
 
 // AuthDevice handles the auth device request and execute its use case
 func (mc *ThingController) AuthDevice(body []byte, authorization string) error {
-	var authThingReq network.AuthThingCommand
+	var authThingReq network.DeviceAuthRequest
 	err := json.Unmarshal(body, &authThingReq)
 	if err != nil {
 		mc.logger.Error(err)
@@ -83,7 +83,7 @@ func (mc *ThingController) AuthDevice(body []byte, authorization string) error {
 
 // RequestData handles the request data request and execute its use case
 func (mc *ThingController) RequestData(body []byte, authorization string) error {
-	var requestDataReq network.RequestDataCommand
+	var requestDataReq network.DataRequest
 	err := json.Unmarshal(body, &requestDataReq)
 	if err != nil {
 		mc.logger.Error(err)

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -20,7 +20,7 @@ const (
 
 // ClientPublisher is the interface with methods that the publisher should have
 type ClientPublisher interface {
-	SendRegisteredDevice(network.RegisterResponseMsg) error
+	SendRegisteredDevice(network.DeviceRegisteredResponse) error
 	SendUnregisteredDevice(thingID string, errMsg *string) error
 	SendUpdatedSchema(thingID string) error
 	SendThings(things []*entities.Thing) error
@@ -40,7 +40,7 @@ func NewMsgClientPublisher(logger logging.Logger, amqp *network.Amqp) ClientPubl
 }
 
 // SendRegisterDevice publishes the registered device's credentials to the device registration queue
-func (mp *msgClientPublisher) SendRegisteredDevice(msg network.RegisterResponseMsg) error {
+func (mp *msgClientPublisher) SendRegisteredDevice(msg network.DeviceRegisteredResponse) error {
 	mp.logger.Debug("Sending registered message")
 	jsonMsg, err := json.Marshal(msg)
 	if err != nil {
@@ -54,7 +54,7 @@ func (mp *msgClientPublisher) SendRegisteredDevice(msg network.RegisterResponseM
 // SendUnregisterDevice publishes the unregistered device's id and error message to the device unregistered queue
 func (mp *msgClientPublisher) SendUnregisteredDevice(thingID string, errMsg *string) error {
 	mp.logger.Debug("Sending unregistered message")
-	resp := &network.UnregisterResponseMsg{ID: thingID, Error: errMsg}
+	resp := &network.DeviceUnregisteredResponse{ID: thingID, Error: errMsg}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		mp.logger.Error(err)
@@ -66,7 +66,7 @@ func (mp *msgClientPublisher) SendUnregisteredDevice(thingID string, errMsg *str
 
 // SendUpdatedSchema sends the updated schema response
 func (mp *msgClientPublisher) SendUpdatedSchema(thingID string) error {
-	resp := &network.UpdatedSchemaResponse{ID: thingID}
+	resp := &network.SchemaUpdatedResponse{ID: thingID}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func (mp *msgClientPublisher) SendUpdatedSchema(thingID string) error {
 
 // SendThings sends the updated schema response
 func (mp *msgClientPublisher) SendThings(things []*entities.Thing) error {
-	resp := &network.ListThingsResponse{Things: things}
+	resp := &network.DeviceListResponse{Things: things}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err
@@ -88,7 +88,7 @@ func (mp *msgClientPublisher) SendThings(things []*entities.Thing) error {
 
 // SendAuthStatus sends the auth thing status response
 func (mp *msgClientPublisher) SendAuthStatus(thingID string, errMsg *string) error {
-	resp := &network.AuthThingResponse{ID: thingID, ErrMsg: errMsg}
+	resp := &network.DeviceAuthResponse{ID: thingID, ErrMsg: errMsg}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err
@@ -99,7 +99,7 @@ func (mp *msgClientPublisher) SendAuthStatus(thingID string, errMsg *string) err
 
 // SendRequestData sends request data command
 func (mp *msgClientPublisher) SendRequestData(thingID string, sensorIds []int) error {
-	resp := &network.RequestDataCommand{ID: thingID, SensorIds: sensorIds}
+	resp := &network.DataRequest{ID: thingID, SensorIds: sensorIds}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -18,12 +18,6 @@ const (
 	requestDataOutKey = "data.request"
 )
 
-// msgClientPublisher handle messages received from a service
-type msgClientPublisher struct {
-	logger logging.Logger
-	amqp   *network.Amqp
-}
-
 // ClientPublisher is the interface with methods that the publisher should have
 type ClientPublisher interface {
 	SendRegisteredDevice(network.RegisterResponseMsg) error
@@ -32,6 +26,12 @@ type ClientPublisher interface {
 	SendThings(things []*entities.Thing) error
 	SendAuthStatus(thingID string, errMsg *string) error
 	SendRequestData(thingID string, sensorIds []int) error
+}
+
+// msgClientPublisher handle messages received from a service
+type msgClientPublisher struct {
+	logger logging.Logger
+	amqp   *network.Amqp
 }
 
 // NewMsgClientPublisher constructs the msgClientPublisher

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -23,7 +23,7 @@ type ClientPublisher interface {
 	SendRegisteredDevice(network.DeviceRegisteredResponse) error
 	SendUnregisteredDevice(thingID string, errMsg *string) error
 	SendUpdatedSchema(thingID string) error
-	SendThings(things []*entities.Thing) error
+	SendDevicesList(things []*entities.Thing) error
 	SendAuthStatus(thingID string, errMsg *string) error
 	SendRequestData(thingID string, sensorIds []int) error
 }
@@ -75,8 +75,8 @@ func (mp *msgClientPublisher) SendUpdatedSchema(thingID string) error {
 	return mp.amqp.PublishPersistentMessage(exchangeFogOut, schemaOutKey, msg)
 }
 
-// SendThings sends the updated schema response
-func (mp *msgClientPublisher) SendThings(things []*entities.Thing) error {
+// SendDevicesList sends the list devices command response
+func (mp *msgClientPublisher) SendDevicesList(things []*entities.Thing) error {
 	resp := &network.DeviceListResponse{Things: things}
 	msg, err := json.Marshal(resp)
 	if err != nil {

--- a/pkg/thing/delivery/amqp/connector.go
+++ b/pkg/thing/delivery/amqp/connector.go
@@ -15,16 +15,16 @@ const (
 	updateSchemaInKey = "schema.update"
 )
 
-type msgConnectorPublisher struct {
-	logger logging.Logger
-	amqp   *network.Amqp
-}
-
 // ConnectorPublisher handle messages received from a service
 type ConnectorPublisher interface {
 	SendRegisterDevice(string, string) error
 	SendUnregisterDevice(string) error
 	SendUpdateSchema(string, []entities.Schema) error
+}
+
+type msgConnectorPublisher struct {
+	logger logging.Logger
+	amqp   *network.Amqp
 }
 
 // NewMsgConnectorPublisher constructs the Connector

--- a/pkg/thing/delivery/amqp/connector.go
+++ b/pkg/thing/delivery/amqp/connector.go
@@ -36,7 +36,7 @@ func NewMsgConnectorPublisher(logger logging.Logger, amqp *network.Amqp) Connect
 func (mp *msgConnectorPublisher) SendRegisterDevice(id string, name string) error {
 	mp.logger.Debug("Sending register message")
 
-	msg := network.RegisterRequestMsg{ID: id, Name: name}
+	msg := network.DeviceRegisterRequest{ID: id, Name: name}
 	bytes, err := json.Marshal(msg)
 	if err != nil {
 		mp.logger.Error(err)
@@ -49,7 +49,7 @@ func (mp *msgConnectorPublisher) SendRegisterDevice(id string, name string) erro
 // SendUnregisterDevice sends an unregister message
 func (mp *msgConnectorPublisher) SendUnregisterDevice(id string) error {
 	mp.logger.Debug("Sending unregister message")
-	msg := network.UnregisterRequestMsg{ID: id}
+	msg := network.DeviceUnregisterRequest{ID: id}
 	bytes, err := json.Marshal(msg)
 	if err != nil {
 		mp.logger.Error(err)
@@ -62,7 +62,7 @@ func (mp *msgConnectorPublisher) SendUnregisterDevice(id string) error {
 // SendUpdateSchema sends an update schema message
 func (mp *msgConnectorPublisher) SendUpdateSchema(id string, schemaList []entities.Schema) error {
 	mp.logger.Info("Sending update schema message to connector")
-	msg := network.UpdateSchemaRequestMsg{ID: id, Schema: schemaList}
+	msg := network.SchemaUpdateRequest{ID: id, Schema: schemaList}
 	bytes, err := json.Marshal(msg)
 	if err != nil {
 		mp.logger.Error(err)

--- a/pkg/thing/interactors/register_thing.go
+++ b/pkg/thing/interactors/register_thing.go
@@ -51,7 +51,7 @@ func (i *ThingInteractor) reply(id, token string, err error) error {
 		errStr = nil
 	}
 
-	response := network.RegisterResponseMsg{ID: id, Token: token, Error: errStr}
+	response := network.DeviceRegisteredResponse{ID: id, Token: token, Error: errStr}
 	errPublish := i.clientPublisher.SendRegisteredDevice(response)
 	if errPublish != nil {
 		i.logger.Error(errPublish)

--- a/pkg/thing/interactors/register_thing_test.go
+++ b/pkg/thing/interactors/register_thing_test.go
@@ -86,7 +86,7 @@ func TestRegisterThing(t *testing.T) {
 				*tmp = tc.fakePublisher.SendError.Error()
 			}
 
-			msg := network.RegisterResponseMsg{ID: tc.thingID, Token: tc.fakePublisher.Token, Error: tmp}
+			msg := network.DeviceRegisteredResponse{ID: tc.thingID, Token: tc.fakePublisher.Token, Error: tmp}
 			tc.fakePublisher.On("SendRegisteredDevice", msg).
 				Return(tc.fakePublisher.ReturnErr)
 			tc.fakeThingProxy.On("Create", tc.thingID, tc.thingName, tc.authorization).

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -16,7 +16,7 @@ type FakePublisher struct {
 }
 
 // SendRegisteredDevice provides a mock function to send a register device response
-func (fp *FakePublisher) SendRegisteredDevice(msg network.RegisterResponseMsg) error {
+func (fp *FakePublisher) SendRegisteredDevice(msg network.DeviceRegisteredResponse) error {
 	ret := fp.Called(msg)
 	return ret.Error(0)
 }

--- a/pkg/user/controllers/user.go
+++ b/pkg/user/controllers/user.go
@@ -18,14 +18,6 @@ type UserController struct {
 	createTokenInteractor *interactors.CreateToken
 }
 
-// NewUserController constructs the controller
-func NewUserController(
-	logger logging.Logger,
-	createUserInteractor *interactors.CreateUser,
-	createTokenInteractor *interactors.CreateToken) *UserController {
-	return &UserController{logger, createUserInteractor, createTokenInteractor}
-}
-
 // CreateTokenResponse is used to map the use case response to HTTP
 type CreateTokenResponse struct {
 	Token string `json:"token"`
@@ -36,36 +28,12 @@ type DetailedErrorResponse struct {
 	Message string `json:"message"`
 }
 
-func (uc *UserController) writeResponse(w http.ResponseWriter, statusCode int, msg interface{}) {
-	w.WriteHeader(statusCode)
-
-	if msg == nil {
-		return
-	}
-
-	js, err := json.Marshal(msg)
-	if err != nil {
-		uc.logger.Errorf("Unable to marshal json: %s", err)
-		return
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	_, err = w.Write(js)
-	if err != nil {
-		uc.logger.Errorf("Unable to write to connection HTTP: %s", err)
-		return
-	}
-}
-
-func mapErrorToStatusCode(err error) int {
-	switch err.(type) {
-	case shared.ErrEntityExists:
-		return http.StatusConflict
-	case entities.ErrInvalidCredentials:
-		return http.StatusForbidden
-	default:
-		return http.StatusInternalServerError
-	}
+// NewUserController constructs the controller
+func NewUserController(
+	logger logging.Logger,
+	createUserInteractor *interactors.CreateUser,
+	createTokenInteractor *interactors.CreateToken) *UserController {
+	return &UserController{logger, createUserInteractor, createTokenInteractor}
 }
 
 // Create godoc
@@ -135,4 +103,36 @@ func (uc *UserController) CreateToken(w http.ResponseWriter, r *http.Request) {
 	uc.logger.Infof("User's %s token created", user.Email)
 	ctr := &CreateTokenResponse{token}
 	uc.writeResponse(w, http.StatusCreated, ctr)
+}
+
+func (uc *UserController) writeResponse(w http.ResponseWriter, statusCode int, msg interface{}) {
+	w.WriteHeader(statusCode)
+
+	if msg == nil {
+		return
+	}
+
+	js, err := json.Marshal(msg)
+	if err != nil {
+		uc.logger.Errorf("Unable to marshal json: %s", err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(js)
+	if err != nil {
+		uc.logger.Errorf("Unable to write to connection HTTP: %s", err)
+		return
+	}
+}
+
+func mapErrorToStatusCode(err error) int {
+	switch err.(type) {
+	case shared.ErrEntityExists:
+		return http.StatusConflict
+	case entities.ErrInvalidCredentials:
+		return http.StatusForbidden
+	default:
+		return http.StatusInternalServerError
+	}
 }


### PR DESCRIPTION
**What does this PR introduce?**

This PR introduces some refactoring (to avoid code repetition) and minor code style changes -- mostly naming and function reordering. 

The following order of appearance was as reference  :point_down:  

1. constant declaration
2. variable declaration
3. interface declaration
4. type declaration
5. newXYZ()/NewXYZ() functions
6. exported functions
7. private functions
8. plain utility functions (in order of usage)

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [ ] Feature
- [X] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**Does this close any currently open issues?**
(Use the special github keywords to reference issues: https://help.github.com/en/articles/closing-issues-using-keywords)

Nope :grimacing: 

**Any relevant logs, error output, etc?**

Nope :smile: 

**Any additional comments?**

Considering changes made in this PR, `pkg/thing/interactors/register_thing.go` is also worthy of refactoring. However, [this](https://github.com/CESARBR/knot-babeltower/pull/46/commits/b23dfd50a1bb9834fb91e6c633f80490cf4fe7eb) commit makes all points addressed in this PR (function order and naming) :confetti_ball: 

**Where has this been tested?**

- Operating System/Platform: Linux 5.5.9-arch1-2 x86_64 GNU/Linux
- Go Version: go1.14 linux/amd64
