### PR TITLE
Add update data message

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -59,3 +59,9 @@ type DataRequest struct {
 	ID        string `json:"id"`
 	SensorIds []int  `json:"sensorIds"`
 }
+
+// DataUpdate represents the incoming update data command
+type DataUpdate struct {
+	ID   string          `json:"id"`
+	Data []entities.Data `json:"data"`
+}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -116,6 +116,8 @@ func (mc *MsgHandler) handleConnectorMessages(msg network.InMsg) error {
 	switch msg.RoutingKey {
 	case "data.request":
 		return mc.thingController.RequestData(msg.Body, authorizationHeader.(string))
+	case "data.update":
+		return mc.thingController.UpdateData(msg.Body, authorizationHeader.(string))
 	case "device.registered":
 		// Ignore message
 	}

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -109,6 +109,5 @@ func (mc *ThingController) UpdateData(body []byte, authorization string) error {
 		return fmt.Errorf("message body parsing error: %w", err)
 	}
 
-	// TODO: call update data interactor
-	return nil
+	return mc.thingInteractor.UpdateData(authorization, msg.ID, msg.Data)
 }

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
 	"github.com/CESARBR/knot-babeltower/pkg/network"
@@ -97,5 +98,17 @@ func (mc *ThingController) RequestData(body []byte, authorization string) error 
 		return err
 	}
 
+	return nil
+}
+
+// UpdateData handles the update data request and execute its use case
+func (mc *ThingController) UpdateData(body []byte, authorization string) error {
+	msg := network.DataUpdate{}
+	err := json.Unmarshal(body, &msg)
+	if err != nil {
+		return fmt.Errorf("message body parsing error: %w", err)
+	}
+
+	// TODO: call update data interactor
 	return nil
 }

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -2,6 +2,7 @@ package amqp
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
 	"github.com/CESARBR/knot-babeltower/pkg/network"
@@ -15,6 +16,7 @@ const (
 	schemaOutKey      = "schema.updated"
 	listThingsOutKey  = "device.list"
 	authDeviceOutKey  = "device.auth"
+	updateDataOutKey  = "data.update"
 	requestDataOutKey = "data.request"
 )
 
@@ -25,6 +27,7 @@ type ClientPublisher interface {
 	SendUpdatedSchema(thingID string) error
 	SendDevicesList(things []*entities.Thing) error
 	SendAuthStatus(thingID string, errMsg *string) error
+	SendUpdateData(thingID string, data []entities.Data) error
 	SendRequestData(thingID string, sensorIds []int) error
 }
 
@@ -107,4 +110,15 @@ func (mp *msgClientPublisher) SendRequestData(thingID string, sensorIds []int) e
 	}
 
 	return mp.amqp.PublishPersistentMessage(exchangeFogOut, requestDataOutKey, msg)
+}
+
+// SendUpdateData send update data command
+func (mp *msgClientPublisher) SendUpdateData(thingID string, data []entities.Data) error {
+	resp := &network.DataUpdate{ID: thingID, Data: data}
+	msg, err := json.Marshal(resp)
+	if err != nil {
+		return fmt.Errorf("message parsing error: %w", err)
+	}
+
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, updateDataOutKey, msg)
 }

--- a/pkg/thing/entities/data.go
+++ b/pkg/thing/entities/data.go
@@ -1,0 +1,7 @@
+package entities
+
+// Data represents the thing's data
+type Data struct {
+	SensorID int         `json:"sensorId"`
+	Value    interface{} `json:"value"`
+}

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -13,6 +13,7 @@ type Interactor interface {
 	Unregister(authorization, id string) error
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
 	List(authorization string) error
+	UpdateData(authorization, thingID string, data []entities.Data) error
 	RequestData(authorization, thingID string, sensorIds []int) error
 	Auth(authorization, id string) error
 }

--- a/pkg/thing/interactors/update_data.go
+++ b/pkg/thing/interactors/update_data.go
@@ -1,0 +1,90 @@
+package interactors
+
+import (
+	"fmt"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+)
+
+var (
+	// ErrNoAuthToken error occur when no authorization token is provided
+	ErrNoAuthToken = fmt.Errorf("missing authorization token")
+
+	// ErrNoIDParam error occur when no thing's id is provided
+	ErrNoIDParam = fmt.Errorf("missing thing's id")
+
+	// ErrNoDataParam error occur when no thing's data is provided
+	ErrNoDataParam = fmt.Errorf("missing thing's data")
+
+	// ErrNoSchema error occur when the thing has no schema yet
+	ErrNoSchema = fmt.Errorf("thing has no schema")
+
+	// ErrDataInvalid error occur when the provided data mismatch the thing's schema
+	ErrDataInvalid = fmt.Errorf("data is incompatible with thing's schema")
+)
+
+// UpdateData executes the use case operations to update data in thing
+func (i *ThingInteractor) UpdateData(authorization, thingID string, data []entities.Data) error {
+	if authorization == "" {
+		return ErrNoAuthToken
+	}
+	if thingID == "" {
+		return ErrNoIDParam
+	}
+	if data == nil {
+		return ErrNoDataParam
+	}
+
+	err := i.verifyThingData(authorization, thingID, data)
+	if err != nil {
+		return fmt.Errorf("error validating thing's data: %w", err)
+	}
+
+	err = i.clientPublisher.SendUpdateData(thingID, data)
+	if err != nil {
+		return fmt.Errorf("error sending message to client: %w", err)
+	}
+
+	i.logger.Info("data update command successfully sent")
+	return nil
+}
+
+func (i *ThingInteractor) verifyThingData(authorization, thingID string, data []entities.Data) error {
+	thing, err := i.thingProxy.Get(authorization, thingID)
+	if err != nil {
+		return fmt.Errorf("error getting thing metadata: %w", err)
+	}
+
+	if thing.Schema == nil {
+		return ErrNoSchema
+	}
+
+	for _, d := range data {
+		if !validateSchema(d, thing.Schema) {
+			return ErrDataInvalid
+		}
+	}
+
+	return nil
+}
+
+func validateSchema(data entities.Data, schema []entities.Schema) bool {
+	for _, s := range schema {
+		if s.SensorID == data.SensorID {
+			switch data.Value.(type) {
+			case int:
+				return s.ValueType == 1 // int
+			case float64:
+				return s.ValueType == 2 // float
+			case bool:
+				return s.ValueType == 3 // bool
+			case string:
+				return s.ValueType == 4 // raw
+			default:
+				return false
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/thing/interactors/update_data_test.go
+++ b/pkg/thing/interactors/update_data_test.go
@@ -1,0 +1,174 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type UpdateDataTestCase struct {
+	name           string
+	authParam      string
+	idParam        string
+	dataParam      []entities.Data
+	fakeLogger     *mocks.FakeLogger
+	fakeThingProxy *mocks.FakeThingProxy
+	fakePublisher  *mocks.FakePublisher
+	expectedError  error
+}
+
+var (
+	errThingProxyGet = errors.New("error in thing's service")
+	errClientSend    = errors.New("error sending message to client")
+)
+
+var voltageSchema = []entities.Schema{entities.Schema{
+	SensorID:  0,
+	ValueType: 1,
+	Unit:      1,
+	TypeID:    1,
+	Name:      "voltage-v",
+}}
+
+var updateDataUseCases = []UpdateDataTestCase{
+	{
+		"authorization token not provided",
+		"",
+		"thing-id",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		ErrNoAuthToken,
+	},
+	{
+		"thing's id not provided",
+		"authorization-token",
+		"",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		ErrNoIDParam,
+	},
+	{
+		"thing's data token not provided",
+		"authorization-token",
+		"thing-id",
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+		ErrNoDataParam,
+	},
+	{
+		"failed to get thing from thing's service",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errThingProxyGet},
+		&mocks.FakePublisher{},
+		errThingProxyGet,
+	},
+	{
+		"thing doesn't have a schema yet",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:    "thing-id",
+			Token: "thing-token",
+			Name:  "thing",
+		}},
+		&mocks.FakePublisher{},
+		ErrNoSchema,
+	},
+	{
+		"data value doesn't match with thing's schema",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 0, Value: false}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakePublisher{},
+		ErrDataInvalid,
+	},
+	{
+		"data sensorId doesn't match with thing's schema",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 1, Value: 5}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakePublisher{},
+		ErrDataInvalid,
+	},
+	{
+		"error publishing message in client exchange",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakePublisher{ReturnErr: errClientSend},
+		errClientSend,
+	},
+	{
+		"message successfuly send to client exchange",
+		"authorization token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakePublisher{},
+		nil,
+	},
+}
+
+func TestUpdateData(t *testing.T) {
+	for _, tc := range updateDataUseCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fakeThingProxy.
+				On("Get", tc.authParam, tc.idParam).
+				Return(tc.fakeThingProxy.Thing, tc.fakeThingProxy.ReturnErr).
+				Maybe()
+			tc.fakePublisher.
+				On("SendUpdateData", tc.idParam, tc.dataParam).
+				Return(tc.fakePublisher.ReturnErr).
+				Maybe()
+
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, nil)
+			err := thingInteractor.UpdateData(tc.authParam, tc.idParam, tc.dataParam)
+
+			assert.EqualValues(t, errors.Is(err, tc.expectedError), true)
+
+			tc.fakeThingProxy.AssertExpectations(t)
+			tc.fakePublisher.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -44,6 +44,12 @@ func (fp *FakePublisher) SendAuthStatus(thingID string, errMsg *string) error {
 	return args.Error(0)
 }
 
+// SendUpdateData provides a mock function to send an update data command
+func (fp *FakePublisher) SendUpdateData(thingID string, data []entities.Data) error {
+	args := fp.Called(thingID, data)
+	return args.Error(0)
+}
+
 // SendRequestData provides a mock function to send a request data command
 func (fp *FakePublisher) SendRequestData(thingID string, sensorIds []int) error {
 	args := fp.Called(thingID, sensorIds)


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch adds the feature of receive, valid and redirect `data.update` amqp messages to babeltower

Where has this been tested?
---------------------------

**Operating System/Platform:** Ubuntu 18.04.4

**Go Version:** go1.13.8

