### PR TITLE
Add publish data message

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -65,3 +65,9 @@ type DataUpdate struct {
 	ID   string          `json:"id"`
 	Data []entities.Data `json:"data"`
 }
+
+// DataPublish represents the incoming publish data command
+type DataPublish struct {
+	ID   string          `json:"id"`
+	Data []entities.Data `json:"data"`
+}

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -118,6 +118,8 @@ func (mc *MsgHandler) handleConnectorMessages(msg network.InMsg) error {
 		return mc.thingController.RequestData(msg.Body, authorizationHeader.(string))
 	case "data.update":
 		return mc.thingController.UpdateData(msg.Body, authorizationHeader.(string))
+	case "data.publish":
+		return mc.thingController.PublishData(msg.Body, authorizationHeader.(string))
 	case "device.registered":
 		// Ignore message
 	}

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -120,6 +120,5 @@ func (mc *ThingController) PublishData(body []byte, authorization string) error 
 		return fmt.Errorf("message body parsing error: %w", err)
 	}
 
-	// TODO: call publish data interactor
-	return nil
+	return mc.thingInteractor.PublishData(authorization, msg.ID, msg.Data)
 }

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -111,3 +111,15 @@ func (mc *ThingController) UpdateData(body []byte, authorization string) error {
 
 	return mc.thingInteractor.UpdateData(authorization, msg.ID, msg.Data)
 }
+
+// PublishData handles the publish data request and execute its use case
+func (mc *ThingController) PublishData(body []byte, authorization string) error {
+	msg := network.DataPublish{}
+	err := json.Unmarshal(body, &msg)
+	if err != nil {
+		return fmt.Errorf("message body parsing error: %w", err)
+	}
+
+	// TODO: call publish data interactor
+	return nil
+}

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -13,8 +13,9 @@ type Interactor interface {
 	Unregister(authorization, id string) error
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
 	List(authorization string) error
-	UpdateData(authorization, thingID string, data []entities.Data) error
 	RequestData(authorization, thingID string, sensorIds []int) error
+	UpdateData(authorization, thingID string, data []entities.Data) error
+	PublishData(authorization, thingID string, data []entities.Data) error
 	Auth(authorization, id string) error
 }
 

--- a/pkg/thing/interactors/publish_data.go
+++ b/pkg/thing/interactors/publish_data.go
@@ -1,0 +1,33 @@
+package interactors
+
+import (
+	"fmt"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+)
+
+// PublishData executes the use case operations to publish data from the things to cloud
+func (i *ThingInteractor) PublishData(authorization, thingID string, data []entities.Data) error {
+	if authorization == "" {
+		return ErrNoAuthToken
+	}
+	if thingID == "" {
+		return ErrNoIDParam
+	}
+	if data == nil {
+		return ErrNoDataParam
+	}
+
+	err := i.verifyThingData(authorization, thingID, data)
+	if err != nil {
+		return fmt.Errorf("error validating thing's data: %w", err)
+	}
+
+	err = i.connectorPublisher.SendPublishData(thingID, data)
+	if err != nil {
+		return fmt.Errorf("error sending message to connector: %w", err)
+	}
+
+	i.logger.Info("publish data message successfully sent")
+	return nil
+}

--- a/pkg/thing/interactors/publish_data_test.go
+++ b/pkg/thing/interactors/publish_data_test.go
@@ -1,0 +1,165 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+type PublishDataTestCase struct {
+	name           string
+	authParam      string
+	idParam        string
+	dataParam      []entities.Data
+	fakeLogger     *mocks.FakeLogger
+	fakeThingProxy *mocks.FakeThingProxy
+	fakeConnector  *mocks.FakeConnector
+	expectedError  error
+}
+
+var (
+	errConnectorSend = errors.New("error sending message to connector")
+)
+
+var publishDataUseCases = []PublishDataTestCase{
+	{
+		"authorization token not provided",
+		"",
+		"thing-id",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakeConnector{},
+		ErrNoAuthToken,
+	},
+	{
+		"thing's id not provided",
+		"authorization-token",
+		"",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakeConnector{},
+		ErrNoIDParam,
+	},
+	{
+		"thing's data token not provided",
+		"authorization-token",
+		"thing-id",
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakeConnector{},
+		ErrNoDataParam,
+	},
+	{
+		"failed to get thing from thing's service",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errThingProxyGet},
+		&mocks.FakeConnector{},
+		errThingProxyGet,
+	},
+	{
+		"thing doesn't have a schema yet",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:    "thing-id",
+			Token: "thing-token",
+			Name:  "thing",
+		}},
+		&mocks.FakeConnector{},
+		ErrNoSchema,
+	},
+	{
+		"data value doesn't match with thing's schema",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 0, Value: false}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakeConnector{},
+		ErrDataInvalid,
+	},
+	{
+		"data sensorId doesn't match with thing's schema",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 1, Value: 5}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakeConnector{},
+		ErrDataInvalid,
+	},
+	{
+		"error publishing message in connector exchange",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakeConnector{SendError: errConnectorSend},
+		errConnectorSend,
+	},
+	{
+		"message successfully sent to connector exchange",
+		"authorization-token",
+		"thing-id",
+		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakeConnector{},
+		nil,
+	},
+}
+
+func TestPublishData(t *testing.T) {
+	for _, tc := range publishDataUseCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fakeThingProxy.
+				On("Get", tc.authParam, tc.idParam).
+				Return(tc.fakeThingProxy.Thing, tc.fakeThingProxy.ReturnErr).
+				Maybe()
+			tc.fakeConnector.
+				On("SendPublishData", tc.idParam, tc.dataParam).
+				Return(tc.fakeConnector.SendError).
+				Maybe()
+
+			thingInteractor := NewThingInteractor(tc.fakeLogger, nil, tc.fakeThingProxy, tc.fakeConnector)
+			err := thingInteractor.PublishData(tc.authParam, tc.idParam, tc.dataParam)
+
+			assert.EqualValues(t, errors.Is(err, tc.expectedError), true)
+
+			tc.fakeThingProxy.AssertExpectations(t)
+			tc.fakeConnector.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/thing/mocks/connector.go
+++ b/pkg/thing/mocks/connector.go
@@ -29,3 +29,9 @@ func (fc *FakeConnector) SendUpdateSchema(id string, schemaList []entities.Schem
 	ret := fc.Called(id, schemaList)
 	return ret.Error(0)
 }
+
+// SendPublishData provides a mock function to send a publish data command to connector
+func (fc *FakeConnector) SendPublishData(id string, data []entities.Data) error {
+	ret := fc.Called(id, data)
+	return ret.Error(0)
+}


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch adds the feature of receive, valid and redirect `data.publish` amqp messages to babeltower

Where has this been tested?
---------------------------

**Operating System/Platform:** Ubuntu 18.04.4

**Go Version:** go1.13.8

