### PR TITLE
Remove token parameter from Auth interactor

### DIFF
--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -78,7 +78,7 @@ func (mc *ThingController) AuthDevice(body []byte, authorization string) error {
 
 	mc.logger.Info("Auth device command received")
 	mc.logger.Debug(authorization, authThingReq)
-	return mc.thingInteractor.Auth(authorization, authThingReq.ID, authThingReq.Token)
+	return mc.thingInteractor.Auth(authorization, authThingReq.ID)
 }
 
 // RequestData handles the request data request and execute its use case

--- a/pkg/thing/interactors/auth_thing.go
+++ b/pkg/thing/interactors/auth_thing.go
@@ -5,18 +5,12 @@ import (
 )
 
 // Auth is responsible to implement the thing's authentication use case
-func (i *ThingInteractor) Auth(authorization, id, token string) error {
-
+func (i *ThingInteractor) Auth(authorization, id string) error {
 	if authorization == "" {
 		return errors.New("authorization key not provided")
 	}
-
 	if id == "" {
 		return errors.New("thing's id not provided")
-	}
-
-	if token == "" {
-		return errors.New("thing's token not provided")
 	}
 
 	_, err := i.thingProxy.Get(authorization, id)

--- a/pkg/thing/interactors/auth_thing_test.go
+++ b/pkg/thing/interactors/auth_thing_test.go
@@ -13,7 +13,6 @@ type AuthThingTestCase struct {
 	name           string
 	authParam      string
 	idParam        string
-	tokenParam     string
 	expectedErr    error
 	fakeLogger     *mocks.FakeLogger
 	fakeThingProxy *mocks.FakeThingProxy
@@ -29,7 +28,6 @@ var atCases = []AuthThingTestCase{
 		"authorization key not provided",
 		"",
 		"8380ba096a091fb9",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		errors.New("authorization key not provided"),
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{},
@@ -40,19 +38,7 @@ var atCases = []AuthThingTestCase{
 		"thing's id not provided",
 		"authorization-token",
 		"",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		errors.New("thing's id not provided"),
-		&mocks.FakeLogger{},
-		&mocks.FakeThingProxy{},
-		&mocks.FakePublisher{},
-		&mocks.FakeConnector{},
-	},
-	{
-		"thing's token not provided",
-		"authorization-token",
-		"8380ba096a091fb9",
-		"",
-		errors.New("thing's token not provided"),
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{},
 		&mocks.FakePublisher{},
@@ -62,7 +48,6 @@ var atCases = []AuthThingTestCase{
 		"thing 6c0dcd9833b595f9 not found",
 		"authorization-token",
 		"6c0dcd9833b595f9",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		entities.ErrThingNotFound{ID: "6c0dcd9833b595f9"},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{ReturnErr: entities.ErrThingNotFound{ID: "6c0dcd9833b595f9"}},
@@ -73,7 +58,6 @@ var atCases = []AuthThingTestCase{
 		"forbidden to authenticate the thing",
 		"invalid-authorization-token",
 		"8380ba096a091fb9",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		&entities.ErrThingForbidden{},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{ReturnErr: &entities.ErrThingForbidden{}},
@@ -84,7 +68,6 @@ var atCases = []AuthThingTestCase{
 		"allowed to authenticate the thing",
 		"authorization-token",
 		"8380ba096a091fb9",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		nil,
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
@@ -99,7 +82,6 @@ var atCases = []AuthThingTestCase{
 		"failed to send the authenticate response",
 		"authorization-token",
 		"8380ba096a091fb9",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		errors.New("failed to send authenticate response"),
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
@@ -114,7 +96,6 @@ var atCases = []AuthThingTestCase{
 		"authenticate response successfully sent",
 		"authorization-token",
 		"8380ba096a091fb9",
-		"b2773648-055e-4b10-af53-df82080c38b3",
 		nil,
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
@@ -140,17 +121,13 @@ func TestAuthThing(t *testing.T) {
 				Maybe()
 
 			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, tc.fakeConnector)
-			err := thingInteractor.Auth(tc.authParam, tc.idParam, tc.tokenParam)
+			err := thingInteractor.Auth(tc.authParam, tc.idParam)
 
 			if tc.authParam == "" {
 				msg := tc.expectedErr.Error()
 				assert.EqualError(t, err, msg)
 			}
 			if tc.idParam == "" {
-				msg := tc.expectedErr.Error()
-				assert.EqualError(t, err, msg)
-			}
-			if tc.tokenParam == "" {
 				msg := tc.expectedErr.Error()
 				assert.EqualError(t, err, msg)
 			}

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -14,16 +14,16 @@ type Interactor interface {
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
 	List(authorization string) error
 	RequestData(authorization, thingID string, sensorIds []int) error
-	Auth(authorization, id, token string) error
+	Auth(authorization, id string) error
 }
 
 // ThingInteractor represents the thing interactor capabilities, it's composed
 // by the necessary dependencies
 type ThingInteractor struct {
-	logger                logging.Logger
-	clientPublisher       amqp.ClientPublisher
-	thingProxy            http.ThingProxy
-	connectorPublisher    amqp.ConnectorPublisher
+	logger             logging.Logger
+	clientPublisher    amqp.ClientPublisher
+	thingProxy         http.ThingProxy
+	connectorPublisher amqp.ConnectorPublisher
 }
 
 // NewThingInteractor creates a new ThingInteractor instance

--- a/pkg/thing/interactors/register_thing.go
+++ b/pkg/thing/interactors/register_thing.go
@@ -7,7 +7,10 @@ import (
 )
 
 var (
+	// ErrIDLength error occur when the thing's id have more than 16 ascii characters
 	ErrIDLength = errors.New("id length exceeds 16 characters")
+
+	// ErrIDNotInHex error occur when the thing's id is not formatted in hexadecimal base
 	ErrIDNotInHex = errors.New("id is not in hexadecimal format")
 )
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch removes the token parameter from Auth interactor and controller

Where has this been tested?
---------------------------

**Operating System/Platform:** Ubuntu 18.04.4

**Go Version:** go1.13.8
