### PR TITLE
Add error field to device.list message response

### DIFF
--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -34,8 +34,8 @@ type SchemaUpdateRequest struct {
 
 // SchemaUpdatedResponse represents the outgoing update schema response message
 type SchemaUpdatedResponse struct {
-	ID     string  `json:"id"`
-	ErrMsg *string `json:"error"`
+	ID    string  `json:"id"`
+	Error *string `json:"error"`
 }
 
 // DeviceAuthRequest represents the incoming auth device command
@@ -46,14 +46,14 @@ type DeviceAuthRequest struct {
 
 // DeviceAuthResponse represents the outgoing auth device command response
 type DeviceAuthResponse struct {
-	ID     string  `json:"id"`
-	ErrMsg *string `json:"error"`
+	ID    string  `json:"id"`
+	Error *string `json:"error"`
 }
 
 // DeviceListResponse represents the outgoing list devices command response
 type DeviceListResponse struct {
 	Things []*entities.Thing `json:"devices"`
-	ErrMsg *string           `json:"error"`
+	Error  *string           `json:"error"`
 }
 
 // DataRequest represents the incoming request data command

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -53,6 +53,7 @@ type DeviceAuthResponse struct {
 // DeviceListResponse represents the outgoing list devices command response
 type DeviceListResponse struct {
 	Things []*entities.Thing `json:"devices"`
+	ErrMsg *string           `json:"error"`
 }
 
 // DataRequest represents the incoming request data command

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -73,7 +73,7 @@ func (mp *msgClientPublisher) SendUnregisteredDevice(thingID string, err error) 
 // SendUpdatedSchema sends the updated schema response
 func (mp *msgClientPublisher) SendUpdatedSchema(thingID string, err error) error {
 	errMsg := getErrMsg(err)
-	resp := &network.SchemaUpdatedResponse{ID: thingID, ErrMsg: errMsg}
+	resp := &network.SchemaUpdatedResponse{ID: thingID, Error: errMsg}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func (mp *msgClientPublisher) SendUpdatedSchema(thingID string, err error) error
 // SendDevicesList sends the list devices command response
 func (mp *msgClientPublisher) SendDevicesList(things []*entities.Thing, err error) error {
 	errMsg := getErrMsg(err)
-	resp := &network.DeviceListResponse{Things: things, ErrMsg: errMsg}
+	resp := &network.DeviceListResponse{Things: things, Error: errMsg}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (mp *msgClientPublisher) SendDevicesList(things []*entities.Thing, err erro
 // SendAuthStatus sends the auth thing status response
 func (mp *msgClientPublisher) SendAuthStatus(thingID string, err error) error {
 	errMsg := getErrMsg(err)
-	resp := &network.DeviceAuthResponse{ID: thingID, ErrMsg: errMsg}
+	resp := &network.DeviceAuthResponse{ID: thingID, Error: errMsg}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -25,7 +25,7 @@ type ClientPublisher interface {
 	SendRegisteredDevice(thingID, token string, err error) error
 	SendUnregisteredDevice(thingID string, err error) error
 	SendUpdatedSchema(thingID string, err error) error
-	SendDevicesList(things []*entities.Thing) error
+	SendDevicesList(things []*entities.Thing, err error) error
 	SendAuthStatus(thingID string, err error) error
 	SendUpdateData(thingID string, data []entities.Data) error
 	SendRequestData(thingID string, sensorIds []int) error
@@ -83,8 +83,9 @@ func (mp *msgClientPublisher) SendUpdatedSchema(thingID string, err error) error
 }
 
 // SendDevicesList sends the list devices command response
-func (mp *msgClientPublisher) SendDevicesList(things []*entities.Thing) error {
-	resp := &network.DeviceListResponse{Things: things}
+func (mp *msgClientPublisher) SendDevicesList(things []*entities.Thing, err error) error {
+	errMsg := getErrMsg(err)
+	resp := &network.DeviceListResponse{Things: things, ErrMsg: errMsg}
 	msg, err := json.Marshal(resp)
 	if err != nil {
 		return err

--- a/pkg/thing/interactors/list_things.go
+++ b/pkg/thing/interactors/list_things.go
@@ -9,13 +9,15 @@ func (i *ThingInteractor) List(authorization string) error {
 	}
 
 	things, err := i.thingProxy.List(authorization)
+	sendErr := i.clientPublisher.SendDevicesList(things, err)
 	if err != nil {
+		if sendErr != nil {
+			return fmt.Errorf("error getting list of things: %v, %w", sendErr, err)
+		}
 		return fmt.Errorf("error getting list of things: %w", err)
 	}
-
-	err = i.clientPublisher.SendDevicesList(things)
-	if err != nil {
-		return fmt.Errorf("error sending response to client: %w", err)
+	if sendErr != nil {
+		return fmt.Errorf("error sending response to client: %w", sendErr)
 	}
 
 	i.logger.Info("devices obtained")

--- a/pkg/thing/interactors/list_things_test.go
+++ b/pkg/thing/interactors/list_things_test.go
@@ -81,7 +81,7 @@ func TestListThings(t *testing.T) {
 				Return(tc.expectedProxyResponseThings, tc.expectedProxyResponseError).
 				Maybe()
 			tc.fakePublisher.
-				On("SendDevicesList", tc.expectedProxyResponseThings).
+				On("SendDevicesList", tc.expectedProxyResponseThings, tc.expectedProxyResponseError).
 				Return(tc.expectedPublisherResponse).
 				Maybe()
 

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -33,8 +33,8 @@ func (fp *FakePublisher) SendUpdatedSchema(thingID string, err error) error {
 }
 
 // SendDevicesList provides a mock function to send a list things response
-func (fp *FakePublisher) SendDevicesList(things []*entities.Thing) error {
-	args := fp.Called(things)
+func (fp *FakePublisher) SendDevicesList(things []*entities.Thing, err error) error {
+	args := fp.Called(things, err)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch adds a `error` argument to `device.list` response

Where has this been tested?
---------------------------

**Operating System/Platform:** Ubuntu 18.04.4

**Go Version:** go1.13.8
