### PR TITLE
Change thing's service development port

### DIFF
--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -13,4 +13,4 @@ rabbitmq:
 
 things:
   hostname: localhost
-  port: 8280
+  port: 8182

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -3,14 +3,3 @@ server:
 
 logger:
   level: debug
-
-users:
-  hostname: localhost
-  port: 8180
-
-rabbitmq:
-  url: amqp://localhost/
-
-things:
-  hostname: localhost
-  port: 8082


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
This patch changes the development port for things service to 8182, which is configured in yaml file for the new core stack.

Where has this been tested?
---------------------------
**Operating System/Platform:** Ubuntu 18.04.4
**Go Version:** go1.13.8
