### PR TITLE
things: proxy: Fix return when fails to list

### DIFF
--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -151,10 +151,11 @@ func (p proxy) UpdateSchema(authorization, ID string, schemaList []entities.Sche
 	return p.mapErrorFromStatusCode(resp.StatusCode)
 }
 
-func (p proxy) List(authorization string) (things []*entities.Thing, err error) {
+func (p proxy) List(authorization string) ([]*entities.Thing, error) {
+	things := []*entities.Thing{}
 	pagThings, err := p.getPaginatedThings(authorization)
 	if err != nil {
-		return nil, nil
+		return things, err
 	}
 
 	for _, t := range pagThings {


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
After requesting the registered things with an invalid user's token, the response message was arriving without a proper error message and an empty things object. This was caused because the thing's proxy list operation didn't return those values when an error is detected. So, this patch fixes it by returning them when the error is checked.

Does this close any currently open issues?
------------------------------------------
Nops.

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments\?
-------------------
Nops.

Where has this been tested?
---------------------------
(Describe your environment setup here.)
npm install remark-lint

**Operating System/Platform:** macOS 10.14 - Darwin 18.0.0
**Go Version:** 1.14
