### PR TITLE
Fix publish data handler

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -12,7 +12,8 @@ const (
 	queueNameConnOut         = "connOut-messages"
 	exchangeConnOut          = "connOut"
 	bindingKeyDevice         = "device.*"
-	bindingKeyData           = "data.*"
+	bindingKeyPublishData    = "data.publish"
+	bindingKeyDataCommands   = "data.*"
 	bindingKeyDeviceCommands = "device.cmd.*"
 	bindingKeySchema         = "schema.*"
 )
@@ -63,9 +64,10 @@ func (mc *MsgHandler) subscribeToMessages(msgChan chan network.InMsg) error {
 	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyDevice)
 	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeySchema)
 	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyDeviceCommands)
+	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyPublishData)
 
 	// Subscribe to messages received from the connector service
-	subscribe(msgChan, queueNameConnOut, exchangeConnOut, bindingKeyData)
+	subscribe(msgChan, queueNameConnOut, exchangeConnOut, bindingKeyDataCommands)
 	subscribe(msgChan, queueNameConnOut, exchangeConnOut, bindingKeyDevice)
 
 	return err
@@ -105,6 +107,8 @@ func (mc *MsgHandler) handleClientMessages(msg network.InMsg) error {
 		return mc.thingController.AuthDevice(msg.Body, authorizationHeader.(string))
 	case "device.cmd.list":
 		return mc.thingController.ListDevices(authorizationHeader.(string))
+	case "data.publish":
+		return mc.thingController.PublishData(msg.Body, authorizationHeader.(string))
 	}
 
 	return nil
@@ -118,8 +122,6 @@ func (mc *MsgHandler) handleConnectorMessages(msg network.InMsg) error {
 		return mc.thingController.RequestData(msg.Body, authorizationHeader.(string))
 	case "data.update":
 		return mc.thingController.UpdateData(msg.Body, authorizationHeader.(string))
-	case "data.publish":
-		return mc.thingController.PublishData(msg.Body, authorizationHeader.(string))
 	case "device.registered":
 		// Ignore message
 	}


### PR DESCRIPTION
What does this implement/fix? Explain your changes
---------------------------------------------------
Before, this service was waiting for receiving published data through
the `connOut` exchange as the command data related ones. However, it
should be received through the `fogIn` exchange since it is prepared
to receive messages from the services that control the things and are
able to inform if a data was published or not. Thus, this patch fixes
this unexpected behavior by subscribing to the right exchange and
moving the handle function call to the `handleClientMessages` method.
Does this close any currently open issues?

Any relevant logs, error output, etc?
-------------------------------------
Nops.

Any other comments?
-------------------
Nops.

Where has this been tested?
---------------------------

**Operating System/Platform:** macOS 10.14 - Darwin 18.0.0

**Go Version:** 1.14