### PR TITLE
Fix thing duplication when registering

### DIFF
--- a/pkg/thing/entities/errors.go
+++ b/pkg/thing/entities/errors.go
@@ -8,4 +8,7 @@ var (
 
 	// ErrThingNotFound represents the error when the schema has a invalid format
 	ErrThingNotFound = errors.New("thing not found on thing's service")
+
+	// ErrThingExists is returned when trying to register an existing thing
+	ErrThingExists = errors.New("thing is already registered")
 )

--- a/pkg/thing/interactors/register_thing.go
+++ b/pkg/thing/interactors/register_thing.go
@@ -3,6 +3,8 @@ package interactors
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 )
 
 // Register runs the use case to create a new thing
@@ -17,10 +19,16 @@ func (i *ThingInteractor) Register(authorization, id, name string) error {
 		return ErrNameNotProvided
 	}
 
-	i.logger.Debug("executing register thing use case")
 	err := i.verifyThingID(id)
 	if err != nil {
 		sendErr := i.sendResponse(id, "", err)
+		return fmt.Errorf("error registering thing: %w", sendErr)
+	}
+
+	// verify if thing is already registered
+	_, err = i.thingProxy.Get(authorization, id)
+	if err == nil {
+		sendErr := i.sendResponse(id, "", entities.ErrThingExists)
 		return fmt.Errorf("error registering thing: %w", sendErr)
 	}
 

--- a/pkg/thing/mocks/thing_proxy.go
+++ b/pkg/thing/mocks/thing_proxy.go
@@ -9,6 +9,7 @@ import (
 type FakeThingProxy struct {
 	mock.Mock
 	ReturnErr error
+	CreateErr error
 	Thing     *entities.Thing
 }
 


### PR DESCRIPTION
**Describe what this PR introduces:**
This patchset fixes the bug of thing duplication when registering a new one. In addition, it updates the unit tests to cover the added checking.

**What kind of change does this PR introduce?**

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS 10.14 - Darwin 18.0.0
- Go version: 1.14
