### PR TITLE
thing: interactor: Fix int validation

### DIFF
--- a/pkg/thing/interactors/publish_data_test.go
+++ b/pkg/thing/interactors/publish_data_test.go
@@ -98,7 +98,7 @@ var publishDataUseCases = []PublishDataTestCase{
 		"data sensorId doesn't match with thing's schema",
 		"authorization-token",
 		"thing-id",
-		[]entities.Data{entities.Data{SensorID: 1, Value: 5}},
+		[]entities.Data{entities.Data{SensorID: 1, Value: float64(5)}},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
 			ID:     "thing-id",
@@ -113,7 +113,7 @@ var publishDataUseCases = []PublishDataTestCase{
 		"error publishing message in connector exchange",
 		"authorization-token",
 		"thing-id",
-		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		[]entities.Data{entities.Data{SensorID: 0, Value: float64(5)}},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
 			ID:     "thing-id",
@@ -128,7 +128,7 @@ var publishDataUseCases = []PublishDataTestCase{
 		"message successfully sent to connector exchange",
 		"authorization-token",
 		"thing-id",
-		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		[]entities.Data{entities.Data{SensorID: 0, Value: float64(5)}},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
 			ID:     "thing-id",

--- a/pkg/thing/interactors/update_data.go
+++ b/pkg/thing/interactors/update_data.go
@@ -2,6 +2,7 @@ package interactors
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 )
@@ -55,9 +56,10 @@ func validateSchema(data entities.Data, schema []entities.Schema) bool {
 	for _, s := range schema {
 		if s.SensorID == data.SensorID {
 			switch data.Value.(type) {
-			case int:
-				return s.ValueType == 1 // int
 			case float64:
+				if data.Value == math.Trunc(data.Value.(float64)) { // check if number is integer
+					return s.ValueType == 1 // int
+				}
 				return s.ValueType == 2 // float
 			case bool:
 				return s.ValueType == 3 // bool

--- a/pkg/thing/interactors/update_data_test.go
+++ b/pkg/thing/interactors/update_data_test.go
@@ -107,7 +107,7 @@ var updateDataUseCases = []UpdateDataTestCase{
 		"data sensorId doesn't match with thing's schema",
 		"authorization-token",
 		"thing-id",
-		[]entities.Data{entities.Data{SensorID: 1, Value: 5}},
+		[]entities.Data{entities.Data{SensorID: 1, Value: float64(5)}},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
 			ID:     "thing-id",
@@ -122,7 +122,7 @@ var updateDataUseCases = []UpdateDataTestCase{
 		"error publishing message in client exchange",
 		"authorization-token",
 		"thing-id",
-		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		[]entities.Data{entities.Data{SensorID: 0, Value: float64(5)}},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
 			ID:     "thing-id",
@@ -137,7 +137,7 @@ var updateDataUseCases = []UpdateDataTestCase{
 		"message successfuly send to client exchange",
 		"authorization token",
 		"thing-id",
-		[]entities.Data{entities.Data{SensorID: 0, Value: 5}},
+		[]entities.Data{entities.Data{SensorID: 0, Value: float64(5)}},
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{Thing: &entities.Thing{
 			ID:     "thing-id",


### PR DESCRIPTION
**Describe what this PR introduces:**

When JSON objects are decoded into a structure that contains generic values, integer numbers are converted to float64 ones. Thus, it causes a bug when validating data operations against the thing's schema. To solve it, this patch validates if the number is really an integer when asserting if it comes as float64.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS 10.14 - Darwin 18.0.0
- Go version: 1.14