### PR TITLE
Migrate auth and list operations to the new request-reply model

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 	thingInteractor := thingInteractors.NewThingInteractor(logrus.Get("ThingInteractor"), clientPublisher, thingProxy, connectorPublisher)
 
 	// Controllers
-	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor)
+	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor, clientPublisher)
 	userController := userControllers.NewUserController(logrus.Get("UserController"), createUser, createToken)
 
 	// Server

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,6 +46,7 @@ func main() {
 	// AMQP Publishers
 	clientPublisher := thingDeliveryAMQP.NewMsgClientPublisher(logrus.Get("ClientPublisher"), amqp)
 	connectorPublisher := thingDeliveryAMQP.NewMsgConnectorPublisher(logrus.Get("ConnectorPublisher"), amqp)
+	commandSender := thingDeliveryAMQP.NewCommandSender(logrus.Get("Command Sender"), amqp)
 
 	// Services
 	userProxy := userDeliveryHTTP.NewUserProxy(logrus.Get("UserProxy"), config.Users.Hostname, config.Users.Port)
@@ -57,7 +58,7 @@ func main() {
 	thingInteractor := thingInteractors.NewThingInteractor(logrus.Get("ThingInteractor"), clientPublisher, thingProxy, connectorPublisher)
 
 	// Controllers
-	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor, clientPublisher)
+	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor, commandSender)
 	userController := userControllers.NewUserController(logrus.Get("UserController"), createUser, createToken)
 
 	// Server

--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -56,8 +56,8 @@ func (a *Amqp) Stop() {
 }
 
 // PublishPersistentMessage sends a persistent message to RabbitMQ
-func (a *Amqp) PublishPersistentMessage(exchange, key string, body []byte) error {
-	err := a.declareExchange(exchange)
+func (a *Amqp) PublishPersistentMessage(exchange, exchangeType, key string, body []byte) error {
+	err := a.declareExchange(exchange, exchangeType)
 	if err != nil {
 		a.logger.Error(err)
 		return err
@@ -86,8 +86,8 @@ func (a *Amqp) PublishPersistentMessage(exchange, key string, body []byte) error
 }
 
 // OnMessage receive messages and put them on channel
-func (a *Amqp) OnMessage(msgChan chan InMsg, queueName, exchangeName, key string) error {
-	err := a.declareExchange(exchangeName)
+func (a *Amqp) OnMessage(msgChan chan InMsg, queueName, exchangeName, exchangeType, key string) error {
+	err := a.declareExchange(exchangeName, exchangeType)
 	if err != nil {
 		a.logger.Error(err)
 		return err
@@ -168,15 +168,15 @@ func (a *Amqp) notifyWhenClosed(started chan bool) {
 	}
 }
 
-func (a *Amqp) declareExchange(name string) error {
+func (a *Amqp) declareExchange(name, exchangeType string) error {
 	return a.channel.ExchangeDeclare(
 		name,
-		amqp.ExchangeTopic, // type
-		true,               // durable
-		false,              // delete when complete
-		false,              // internal
-		false,              // noWait
-		nil,                // arguments
+		exchangeType, // type
+		true,         // durable
+		false,        // delete when complete
+		false,        // internal
+		false,        // noWait
+		nil,          // arguments
 	)
 }
 

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -9,10 +9,12 @@ import (
 )
 
 const (
-	queueNameFogIn           = "fogIn-messages"
+	queueFogIn               = "fogIn-messages"
 	exchangeFogIn            = "fogIn"
-	queueNameConnOut         = "connOut-messages"
+	exchangeTypeFogIn        = "topic"
+	queueConnOut             = "connOut-messages"
 	exchangeConnOut          = "connOut"
+	exchangeTypeConnOut      = "topic"
 	bindingKeyDevice         = "device.*"
 	bindingKeyPublishData    = "data.publish"
 	bindingKeyDataCommands   = "data.*"
@@ -55,22 +57,22 @@ func (mc *MsgHandler) Stop() {
 
 func (mc *MsgHandler) subscribeToMessages(msgChan chan network.InMsg) error {
 	var err error
-	subscribe := func(msgChan chan network.InMsg, queueName, exchange, key string) {
+	subscribe := func(msgChan chan network.InMsg, queue, exchange, kind, key string) {
 		if err != nil {
 			return
 		}
-		err = mc.amqp.OnMessage(msgChan, queueName, exchange, key)
+		err = mc.amqp.OnMessage(msgChan, queue, exchange, kind, key)
 	}
 
 	// Subscribe to messages received from any client
-	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyDevice)
-	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeySchema)
-	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyDeviceCommands)
-	subscribe(msgChan, queueNameFogIn, exchangeFogIn, bindingKeyPublishData)
+	subscribe(msgChan, queueFogIn, exchangeFogIn, exchangeTypeFogIn, bindingKeyDevice)
+	subscribe(msgChan, queueFogIn, exchangeFogIn, exchangeTypeFogIn, bindingKeySchema)
+	subscribe(msgChan, queueFogIn, exchangeFogIn, exchangeTypeFogIn, bindingKeyDeviceCommands)
+	subscribe(msgChan, queueFogIn, exchangeFogIn, exchangeTypeFogIn, bindingKeyPublishData)
 
 	// Subscribe to messages received from the connector service
-	subscribe(msgChan, queueNameConnOut, exchangeConnOut, bindingKeyDataCommands)
-	subscribe(msgChan, queueNameConnOut, exchangeConnOut, bindingKeyDevice)
+	subscribe(msgChan, queueConnOut, exchangeConnOut, exchangeTypeConnOut, bindingKeyDataCommands)
+	subscribe(msgChan, queueConnOut, exchangeConnOut, exchangeTypeConnOut, bindingKeyDevice)
 
 	return err
 }

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -64,12 +64,12 @@ func (mc *ThingController) UpdateSchema(body []byte, authorizationHeader string)
 }
 
 // ListDevices handles the list devices request and execute its use case
-func (mc *ThingController) ListDevices(authorization string) error {
+func (mc *ThingController) ListDevices(authorization, corrID string) error {
 	return mc.thingInteractor.List(authorization)
 }
 
 // AuthDevice handles the auth device request and execute its use case
-func (mc *ThingController) AuthDevice(body []byte, authorization string) error {
+func (mc *ThingController) AuthDevice(body []byte, authorization, corrID string) error {
 	var authThingReq network.DeviceAuthRequest
 	err := json.Unmarshal(body, &authThingReq)
 	if err != nil {

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -14,12 +14,12 @@ import (
 type ThingController struct {
 	logger          logging.Logger
 	thingInteractor interactors.Interactor
-	clientPublisher amqp.ClientPublisher
+	sender          amqp.Sender
 }
 
 // NewThingController constructs the ThingController
-func NewThingController(logger logging.Logger, thingInteractor interactors.Interactor, clientPublisher amqp.ClientPublisher) *ThingController {
-	return &ThingController{logger, thingInteractor, clientPublisher}
+func NewThingController(logger logging.Logger, thingInteractor interactors.Interactor, sender amqp.Sender) *ThingController {
+	return &ThingController{logger, thingInteractor, sender}
 }
 
 // Register handles the register device request and execute its use case
@@ -70,14 +70,14 @@ func (mc *ThingController) ListDevices(authorization, corrID string) error {
 	mc.logger.Info("list devices command received")
 	things, err := mc.thingInteractor.List(authorization)
 	if err != nil {
-		sendErr := mc.clientPublisher.SendDevicesList(things, err)
+		sendErr := mc.sender.SendListResponse(things, corrID, err)
 		if sendErr != nil {
 			return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 		}
 		return err
 	}
 
-	sendErr := mc.clientPublisher.SendDevicesList(things, err)
+	sendErr := mc.sender.SendListResponse(things, corrID, err)
 	if sendErr != nil {
 		return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 	}
@@ -97,14 +97,14 @@ func (mc *ThingController) AuthDevice(body []byte, authorization, corrID string)
 	mc.logger.Info("auth device command received")
 	err = mc.thingInteractor.Auth(authorization, authThingReq.ID)
 	if err != nil {
-		sendErr := mc.clientPublisher.SendAuthStatus(authThingReq.ID, err)
+		sendErr := mc.sender.SendAuthResponse(authThingReq.ID, corrID, err)
 		if sendErr != nil {
 			return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 		}
 		return err
 	}
 
-	sendErr := mc.clientPublisher.SendAuthStatus(authThingReq.ID, err)
+	sendErr := mc.sender.SendAuthResponse(authThingReq.ID, corrID, err)
 	if sendErr != nil {
 		return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 	}

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -53,7 +53,7 @@ func (mp *msgClientPublisher) SendRegisteredDevice(thingID, token string, err er
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, registerOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", registerOutKey, msg)
 }
 
 // SendUnregisterDevice publishes the unregistered device's id and error message to the device unregistered queue
@@ -67,7 +67,7 @@ func (mp *msgClientPublisher) SendUnregisteredDevice(thingID string, err error) 
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, unregisterOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", unregisterOutKey, msg)
 }
 
 // SendUpdatedSchema sends the updated schema response
@@ -79,7 +79,7 @@ func (mp *msgClientPublisher) SendUpdatedSchema(thingID string, err error) error
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, schemaOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", schemaOutKey, msg)
 }
 
 // SendDevicesList sends the list devices command response
@@ -91,7 +91,7 @@ func (mp *msgClientPublisher) SendDevicesList(things []*entities.Thing, err erro
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, listThingsOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", listThingsOutKey, msg)
 }
 
 // SendAuthStatus sends the auth thing status response
@@ -103,7 +103,7 @@ func (mp *msgClientPublisher) SendAuthStatus(thingID string, err error) error {
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, authDeviceOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", authDeviceOutKey, msg)
 }
 
 // SendRequestData sends request data command
@@ -114,7 +114,7 @@ func (mp *msgClientPublisher) SendRequestData(thingID string, sensorIds []int) e
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, requestDataOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", requestDataOutKey, msg)
 }
 
 // SendUpdateData send update data command
@@ -125,7 +125,7 @@ func (mp *msgClientPublisher) SendUpdateData(thingID string, data []entities.Dat
 		return fmt.Errorf("message parsing error: %w", err)
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeFogOut, updateDataOutKey, msg)
+	return mp.amqp.PublishPersistentMessage(exchangeFogOut, "topic", updateDataOutKey, msg)
 }
 
 func getErrMsg(err error) *string {

--- a/pkg/thing/delivery/amqp/connector.go
+++ b/pkg/thing/delivery/amqp/connector.go
@@ -46,7 +46,7 @@ func (mp *msgConnectorPublisher) SendRegisterDevice(id string, name string) erro
 		return err
 	}
 	// TODO: receive message
-	return mp.amqp.PublishPersistentMessage(exchangeConnIn, registerInKey, bytes)
+	return mp.amqp.PublishPersistentMessage(exchangeConnIn, "topic", registerInKey, bytes)
 }
 
 // SendUnregisterDevice sends an unregister message
@@ -59,7 +59,7 @@ func (mp *msgConnectorPublisher) SendUnregisterDevice(id string) error {
 		return err
 	}
 
-	return mp.amqp.PublishPersistentMessage(exchangeConnIn, unregisterInKey, bytes)
+	return mp.amqp.PublishPersistentMessage(exchangeConnIn, "topic", unregisterInKey, bytes)
 }
 
 // SendUpdateSchema sends an update schema message
@@ -71,7 +71,7 @@ func (mp *msgConnectorPublisher) SendUpdateSchema(id string, schemaList []entiti
 		mp.logger.Error(err)
 		return err
 	}
-	return mp.amqp.PublishPersistentMessage(exchangeConnIn, updateSchemaInKey, bytes)
+	return mp.amqp.PublishPersistentMessage(exchangeConnIn, "topic", updateSchemaInKey, bytes)
 }
 
 // SendPublishData sends a publish data message
@@ -82,5 +82,5 @@ func (mp *msgConnectorPublisher) SendPublishData(id string, data []entities.Data
 	if err != nil {
 		return fmt.Errorf("message parsing error: %w", err)
 	}
-	return mp.amqp.PublishPersistentMessage(exchangeConnIn, publishDataInKey, bytes)
+	return mp.amqp.PublishPersistentMessage(exchangeConnIn, "topic", publishDataInKey, bytes)
 }

--- a/pkg/thing/interactors/auth_thing.go
+++ b/pkg/thing/interactors/auth_thing.go
@@ -13,18 +13,8 @@ func (i *ThingInteractor) Auth(authorization, id string) error {
 
 	_, err := i.thingProxy.Get(authorization, id)
 	if err != nil {
-		sendErr := i.clientPublisher.SendAuthStatus(id, err)
-		if sendErr != nil {
-			return fmt.Errorf("error getting thing metadata: %v: %w", sendErr, err)
-		}
-		return fmt.Errorf("error getting thing metadata: %w", err)
+		return fmt.Errorf("can't receive thing metadata: %w", err)
 	}
 
-	err = i.clientPublisher.SendAuthStatus(id, nil)
-	if err != nil {
-		return fmt.Errorf("error sending response to client: %w", err)
-	}
-
-	i.logger.Info("authentication status sucessfully sent")
 	return nil
 }

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -12,7 +12,7 @@ type Interactor interface {
 	Register(authorization, id, name string) error
 	Unregister(authorization, id string) error
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
-	List(authorization string) error
+	List(authorization string) ([]*entities.Thing, error)
 	RequestData(authorization, thingID string, sensorIds []int) error
 	UpdateData(authorization, thingID string, data []entities.Data) error
 	PublishData(authorization, thingID string, data []entities.Data) error

--- a/pkg/thing/interactors/list_things.go
+++ b/pkg/thing/interactors/list_things.go
@@ -1,25 +1,22 @@
 package interactors
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+)
 
 // List fetchs the registered things and return them as an array
-func (i *ThingInteractor) List(authorization string) error {
+func (i *ThingInteractor) List(authorization string) ([]*entities.Thing, error) {
 	if authorization == "" {
-		return ErrAuthNotProvided
+		return nil, ErrAuthNotProvided
 	}
 
 	things, err := i.thingProxy.List(authorization)
-	sendErr := i.clientPublisher.SendDevicesList(things, err)
 	if err != nil {
-		if sendErr != nil {
-			return fmt.Errorf("error getting list of things: %v, %w", sendErr, err)
-		}
-		return fmt.Errorf("error getting list of things: %w", err)
-	}
-	if sendErr != nil {
-		return fmt.Errorf("error sending response to client: %w", sendErr)
+		return nil, fmt.Errorf("error getting list of things: %w", err)
 	}
 
 	i.logger.Info("devices obtained")
-	return nil
+	return things, nil
 }

--- a/pkg/thing/interactors/list_things.go
+++ b/pkg/thing/interactors/list_things.go
@@ -17,6 +17,5 @@ func (i *ThingInteractor) List(authorization string) ([]*entities.Thing, error) 
 		return nil, fmt.Errorf("error getting list of things: %w", err)
 	}
 
-	i.logger.Info("devices obtained")
 	return things, nil
 }

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -32,18 +32,6 @@ func (fp *FakePublisher) SendUpdatedSchema(thingID string, err error) error {
 	return ret.Error(0)
 }
 
-// SendDevicesList provides a mock function to send a list things response
-func (fp *FakePublisher) SendDevicesList(things []*entities.Thing, err error) error {
-	args := fp.Called(things, err)
-	return args.Error(0)
-}
-
-// SendAuthStatus provides a mock function to send auth thing command response
-func (fp *FakePublisher) SendAuthStatus(thingID string, err error) error {
-	args := fp.Called(thingID, err)
-	return args.Error(0)
-}
-
 // SendUpdateData provides a mock function to send an update data command
 func (fp *FakePublisher) SendUpdateData(thingID string, data []entities.Data) error {
 	args := fp.Called(thingID, data)


### PR DESCRIPTION
**Describe what this PR introduces:** 

This patch set migrates `auth` and `list` devices operations to be compliant with the new [AMQP API](https://github.com/CESARBR/knot-babeltower/blob/master/docs/events.md).

related to #59

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?**

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

Authenticate and list devices operations are no longer supported through `topic` exchanges. In order to achieve compatibility again, the clients must send the request to a `direct` exchange and pass a correlation via headers. The command response should be received by listening to that `direct` exchange and filter by using the correlation ID as the new binding key.

**The PR fulfills these requirements:**

- [x] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: MacOS - darwin/amd64
- Go version: 1.14