### PR TITLE
refactor:thing: Change authorization-key to authorization-token

### DIFF
--- a/pkg/thing/interactors/auth_thing_test.go
+++ b/pkg/thing/interactors/auth_thing_test.go
@@ -22,7 +22,7 @@ type AuthThingTestCase struct {
 
 var atCases = []AuthThingTestCase{
 	{
-		"authorization key not provided",
+		"authorization token not provided",
 		"",
 		"8380ba096a091fb9",
 		ErrAuthNotProvided,

--- a/pkg/thing/interactors/list_things_test.go
+++ b/pkg/thing/interactors/list_things_test.go
@@ -24,7 +24,7 @@ type listThingsTestCase struct {
 
 var ltCases = []listThingsTestCase{
 	{
-		"authorization key not passed",
+		"authorization token not provided",
 		"",
 		ErrAuthNotProvided,
 		[]*entities.Thing{},
@@ -37,7 +37,7 @@ var ltCases = []listThingsTestCase{
 	},
 	{
 		"failed to list things from thing's service",
-		"authorization token",
+		"authorization-token",
 		errors.New("thing's service unavailable"),
 		[]*entities.Thing{},
 		errors.New("thing's service unavailable"),
@@ -49,7 +49,7 @@ var ltCases = []listThingsTestCase{
 	},
 	{
 		"things successfully published to message queue",
-		"authorization token",
+		"authorization-token",
 		nil,
 		[]*entities.Thing{},
 		nil,
@@ -61,7 +61,7 @@ var ltCases = []listThingsTestCase{
 	},
 	{
 		"failed to publish list things response",
-		"authorization key",
+		"authorization-token",
 		errors.New("message queue unavailable"),
 		[]*entities.Thing{},
 		nil,

--- a/pkg/thing/interactors/request_data_test.go
+++ b/pkg/thing/interactors/request_data_test.go
@@ -24,7 +24,7 @@ type GetDataTestCase struct {
 
 var gdCases = []GetDataTestCase{
 	{
-		"authorization key not provided",
+		"authorization token not provided",
 		"",
 		"",
 		nil,
@@ -36,8 +36,8 @@ var gdCases = []GetDataTestCase{
 		&mocks.FakePublisher{},
 	},
 	{
-		"failed to authenticate with provided key",
-		"authorization-key",
+		"failed to authenticate with provided token",
+		"authorization-token",
 		"fc3fcf912d0c290a",
 		nil,
 		nil,
@@ -49,7 +49,7 @@ var gdCases = []GetDataTestCase{
 	},
 	{
 		"thing doesn't exists on thing's service",
-		"authorization-key",
+		"authorization-token",
 		"fc3fcf912d0c290a",
 		nil,
 		nil,
@@ -61,7 +61,7 @@ var gdCases = []GetDataTestCase{
 	},
 	{
 		"thing successfully obtained from the thing's service",
-		"authorization-key",
+		"authorization-token",
 		"fc3fcf912d0c290a",
 		[]int{2},
 		&entities.Thing{
@@ -86,7 +86,7 @@ var gdCases = []GetDataTestCase{
 	},
 	{
 		"thing hasn't schema for the requested sensor",
-		"authorization-key",
+		"authorization-token",
 		"fc3fcf912d0c290a",
 		[]int{1}, // the sensor id 1 can't be mapped to thing's schema
 		&entities.Thing{
@@ -111,7 +111,7 @@ var gdCases = []GetDataTestCase{
 	},
 	{
 		"failed to send quest data command to message queue",
-		"authorization key",
+		"authorization-token",
 		"fc3fcf912d0c290a",
 		[]int{1},
 		&entities.Thing{
@@ -136,7 +136,7 @@ var gdCases = []GetDataTestCase{
 	},
 	{
 		"request data command successfully sent",
-		"authorization key",
+		"authorization-token",
 		"fc3fcf912d0c290a",
 		[]int{1},
 		&entities.Thing{

--- a/pkg/thing/interactors/unregister_thing_test.go
+++ b/pkg/thing/interactors/unregister_thing_test.go
@@ -21,7 +21,7 @@ type UnregisterThingTestCase struct {
 
 var unregisterAtCases = []UnregisterThingTestCase{
 	{
-		"authorization key not provided",
+		"authorization token not provided",
 		"",
 		"thing-id",
 		&mocks.FakeLogger{},

--- a/pkg/thing/interactors/update_data_test.go
+++ b/pkg/thing/interactors/update_data_test.go
@@ -135,7 +135,7 @@ var updateDataUseCases = []UpdateDataTestCase{
 	},
 	{
 		"message successfuly send to client exchange",
-		"authorization token",
+		"authorization-token",
 		"thing-id",
 		[]entities.Data{entities.Data{SensorID: 0, Value: float64(5)}},
 		&mocks.FakeLogger{},

--- a/pkg/thing/interactors/update_schema_test.go
+++ b/pkg/thing/interactors/update_schema_test.go
@@ -33,7 +33,7 @@ type UpdateSchemaTestCase struct {
 var tCases = []UpdateSchemaTestCase{
 	{
 		"schema successfully updated on the thing's proxy",
-		"authorization token",
+		"authorization-token",
 		"19cf40c23012ce1c",
 		nil,
 		[]entities.Schema{
@@ -54,7 +54,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"failed to update the schema on the thing's proxy",
-		"authorization token",
+		"authorization-token",
 		"29cf40c23012ce1c",
 		errThingProxyFailed,
 		[]entities.Schema{
@@ -75,7 +75,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"schema response successfully sent",
-		"authorization token",
+		"authorization-token",
 		"39cf40c23012ce1c",
 		nil,
 		[]entities.Schema{
@@ -96,7 +96,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"failed to send updated schema response",
-		"authorization token",
+		"authorization-token",
 		"49cf40c23012ce1c",
 		errPublisherClientFailed,
 		[]entities.Schema{
@@ -117,7 +117,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"failed to send update schema to connector",
-		"authorization token",
+		"authorization-token",
 		"59cf40c23012ce1c",
 		errPublisherConnectorFailed,
 		[]entities.Schema{
@@ -138,7 +138,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"invalid schema type ID",
-		"authorization token",
+		"authorization-token",
 		"69cf40c23012ce1c",
 		errSchemaInvalid,
 		[]entities.Schema{
@@ -159,7 +159,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"invalid schema unit",
-		"authorization token",
+		"authorization-token",
 		"79cf40c23012ce1c",
 		errSchemaInvalid,
 		[]entities.Schema{
@@ -180,7 +180,7 @@ var tCases = []UpdateSchemaTestCase{
 	},
 	{
 		"invalid schema name",
-		"authorization token",
+		"authorization-token",
 		"89cf40c23012ce1c",
 		errSchemaInvalid,
 		[]entities.Schema{


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** (if necessary, link currently open issues with [special keywords](https://help.github.com/en/articles/closing-issues-using-keywords))

In order to have a code standard, this commit changes the authentication parameter to authorization-token in the interactor test cases. Also changes the string `not passed` to `not provided`

close #68

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform:
- Go version:

If you have relevant logs, error output and etc, please attach them.

**Other information:**
