### PR TITLE
Adjust publish data to new API

### DIFF
--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -56,7 +56,7 @@ func (a *Amqp) Stop() {
 }
 
 // PublishPersistentMessage sends a persistent message to RabbitMQ
-func (a *Amqp) PublishPersistentMessage(exchange, exchangeType, key string, body []byte) error {
+func (a *Amqp) PublishPersistentMessage(exchange, exchangeType, key string, body []byte, headers amqp.Table) error {
 	err := a.declareExchange(exchange, exchangeType)
 	if err != nil {
 		a.logger.Error(err)
@@ -69,7 +69,7 @@ func (a *Amqp) PublishPersistentMessage(exchange, exchangeType, key string, body
 		false, // mandatory
 		false, // immediate
 		amqp.Publishing{
-			Headers:         amqp.Table{},
+			Headers:         headers,
 			ContentType:     "text/plain",
 			ContentEncoding: "",
 			Body:            body,

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -70,8 +70,8 @@ type DataUpdate struct {
 	Data []entities.Data `json:"data"`
 }
 
-// DataPublish represents the incoming publish data command
-type DataPublish struct {
+// DataSent represents the data received from the things
+type DataSent struct {
 	ID   string          `json:"id"`
 	Data []entities.Data `json:"data"`
 }

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -144,7 +144,7 @@ func (mc *ThingController) UpdateData(body []byte, authorization string) error {
 
 // PublishData handles the publish data request and execute its use case
 func (mc *ThingController) PublishData(body []byte, authorization string) error {
-	msg := network.DataPublish{}
+	msg := network.DataSent{}
 	err := json.Unmarshal(body, &msg)
 	if err != nil {
 		return fmt.Errorf("message body parsing error: %w", err)

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -59,7 +59,7 @@ func NewCommandSender(logger logging.Logger, amqp *network.Amqp) Sender {
 	return &commandSender{logger, amqp}
 }
 
-// PublishRegisterDevice publishes the registered device's credentials to the device registration queue
+// PublishRegisteredDevice publishes the registered device's credentials to the device registration queue
 func (mp *msgClientPublisher) PublishRegisteredDevice(thingID, name, token string, err error) error {
 	mp.logger.Debug("sending registered message")
 	errMsg := getErrMsg(err)
@@ -73,7 +73,7 @@ func (mp *msgClientPublisher) PublishRegisteredDevice(thingID, name, token strin
 	return mp.amqp.PublishPersistentMessage(exchangeDevices, exchangeDevicesType, registerOutKey, msg, nil)
 }
 
-// PublishUnregisterDevice publishes the unregistered device's id and error message to the device unregistered queue
+// PublishUnregisteredDevice publishes the unregistered device's id and error message to the device unregistered queue
 func (mp *msgClientPublisher) PublishUnregisteredDevice(thingID string, err error) error {
 	mp.logger.Debug("sending unregistered message")
 	errMsg := getErrMsg(err)
@@ -147,7 +147,7 @@ func (cs *commandSender) SendListResponse(things []*entities.Thing, corrID strin
 	return cs.amqp.PublishPersistentMessage(exchangeDevices, exchangeDevicesType, corrID, msg, nil)
 }
 
-// PublishUpdateData send update data command
+// PublishPublishedData send update data command
 func (mp *msgClientPublisher) PublishPublishedData(thingID, token string, data []entities.Data) error {
 	resp := &network.DataSent{ID: thingID, Data: data}
 	headers := map[string]interface{}{

--- a/pkg/thing/interactors/publish_data.go
+++ b/pkg/thing/interactors/publish_data.go
@@ -23,7 +23,7 @@ func (i *ThingInteractor) PublishData(authorization, thingID string, data []enti
 		return fmt.Errorf("error validating thing's data: %w", err)
 	}
 
-	err = i.publisher.PublishPublishedData(thingID, data)
+	err = i.publisher.PublishPublishedData(thingID, authorization, data)
 	if err != nil {
 		return fmt.Errorf("error sending message to client: %w", err)
 	}

--- a/pkg/thing/mocks/publisher.go
+++ b/pkg/thing/mocks/publisher.go
@@ -45,7 +45,7 @@ func (fp *FakePublisher) PublishRequestData(thingID string, sensorIds []int) err
 }
 
 // PublishPublishedData provides a mock function to send a request data command
-func (fp *FakePublisher) PublishPublishedData(thingID string, data []entities.Data) error {
+func (fp *FakePublisher) PublishPublishedData(thingID, token string, data []entities.Data) error {
 	args := fp.Called(thingID, data)
 	return args.Error(0)
 }


### PR DESCRIPTION
**Describe what this PR introduces:** 

This PR updates the sending of `data.published` to send authorization token and rename the network message structure from `DataPublish` to `DataSent`.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [X] Other, please describe: adjustments to new API

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin 18.0.0
- Go version: 1.14

If you have relevant logs, error output and etc, please attach them.

**Other information:**
