### PR TITLE
Fix header name

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -165,14 +165,14 @@ Event that represents a device sending its schema to the services that are inter
 
 ### **device.list** <a name="device-list"></a>
 
-Event-command to list the registered things. It follows the request/reply pattern. After obtaining the things, `babeltower` will send a reply message by using the `correlation_id` property, which wass received in the request header, as reply message's `routing_key`. Because of that, considering the **requestor** has created and sent this `correlation_id` in the request, it can also subscribe to receive events that arrive with a `routing_key` equivalent to the `correlation_id`. Therefore, the reply is received by the application that has sent the request, in a **one-to-one** manner.
+Event-command to list the registered things. It follows the request/reply pattern. After obtaining the things, `babeltower` will send a reply message by using the `reply_to` property, which was received in the request header, as reply message's `routing_key`. Because of that, considering the **requestor** has created and sent this `reply_to` in the request, it can also subscribe to receive events that arrive in a queue associated with the `reply_to`. Therefore, the reply is received by the application that has sent the request, in a **one-to-one** manner.
 
 <details>
   <summary>Headers</summary>
 
   - `token` **String** user's token
-  - `correlation_id` **String** ID to correlate request/reply
-  - `reply_to` **String** queue that will process the reply
+  - `reply_to` **String** reply's queue name
+  - `correlation_id` **String** ID to correlate reply-request after message arrived in the queue
 
 </details>
 
@@ -200,20 +200,20 @@ Event-command to list the registered things. It follows the request/reply patter
     - Name: device
     - Durable: `true`
     - Auto-delete: `false`
-  - Routing key: `correlation_id`
+  - Routing key: `reply_to`
 
 </details>
 
 ### **device.auth** <a name="device-auth"></a>
 
-Event-command to verify if a thing is authenticated based on its credentials. It follows the request/reply pattern. After authenticating the device, `babeltower` will send a reply message by using the `correlation_id` property, which is received in the request header, as reply message's `routing_key`. Because of that, considering the **requestor** has created and sent this `correlation_id` in the request, it can also subscribe to receive events that arrive with a `routing_key` equivalent to the `correlation_id`. Therefore, the reply is received by the application that has sent the request, in a **one-to-one** manner.
+Event-command to verify if a thing is authenticated based on its credentials. It follows the request/reply pattern. After authenticating the device, `babeltower` will send a reply message by using the `reply_to` property, which is received in the request header, as reply message's `routing_key`. Because of that, considering the **requestor** has created and sent this `reply_to` in the request, it can also subscribe to receive events that arrive in a queue associated with the `reply_to`. Therefore, the reply is received by the application that has sent the request, in a **one-to-one** manner.
 
 <details>
   <summary>Headers</summary>
 
   - `token` **String** user's token
-  - `correlation_id` **String** ID to correlate reply/response
-  - `reply_to` **String** queue that will process the reply
+  - `reply_to` **String** reply's queue name
+  - `correlation_id` **String** ID to correlate reply-request after message arrived in the queue
 
 </details>
 
@@ -243,7 +243,7 @@ Event-command to verify if a thing is authenticated based on its credentials. It
     - Name: device
     - Durable: `true`
     - Auto-delete: `false`
-  - Routing key: `correlation_id`
+  - Routing key: `reply_to`
 
 </details>
 

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -66,18 +66,18 @@ func (mc *ThingController) UpdateSchema(body []byte, authorizationHeader string)
 }
 
 // ListDevices handles the list devices request and execute its use case
-func (mc *ThingController) ListDevices(authorization, corrID string) error {
+func (mc *ThingController) ListDevices(authorization, replyTo, corrID string) error {
 	mc.logger.Info("list devices command received")
 	things, err := mc.thingInteractor.List(authorization)
 	if err != nil {
-		sendErr := mc.sender.SendListResponse(things, corrID, err)
+		sendErr := mc.sender.SendListResponse(things, replyTo, corrID, err)
 		if sendErr != nil {
 			return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 		}
 		return err
 	}
 
-	sendErr := mc.sender.SendListResponse(things, corrID, err)
+	sendErr := mc.sender.SendListResponse(things, replyTo, corrID, err)
 	if sendErr != nil {
 		return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 	}
@@ -86,7 +86,7 @@ func (mc *ThingController) ListDevices(authorization, corrID string) error {
 }
 
 // AuthDevice handles the auth device request and execute its use case
-func (mc *ThingController) AuthDevice(body []byte, authorization, corrID string) error {
+func (mc *ThingController) AuthDevice(body []byte, authorization, replyTo, corrID string) error {
 	var authThingReq network.DeviceAuthRequest
 	err := json.Unmarshal(body, &authThingReq)
 	if err != nil {
@@ -97,14 +97,14 @@ func (mc *ThingController) AuthDevice(body []byte, authorization, corrID string)
 	mc.logger.Info("auth device command received")
 	err = mc.thingInteractor.Auth(authorization, authThingReq.ID)
 	if err != nil {
-		sendErr := mc.sender.SendAuthResponse(authThingReq.ID, corrID, err)
+		sendErr := mc.sender.SendAuthResponse(authThingReq.ID, replyTo, corrID, err)
 		if sendErr != nil {
 			return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 		}
 		return err
 	}
 
-	sendErr := mc.sender.SendAuthResponse(authThingReq.ID, corrID, err)
+	sendErr := mc.sender.SendAuthResponse(authThingReq.ID, replyTo, corrID, err)
 	if sendErr != nil {
 		return fmt.Errorf("error sending response: %v: %w", err, sendErr)
 	}


### PR DESCRIPTION
**Describe what this PR introduces:**

After noticing a confusion about `correlation_id` and `reply_to` headers in auth/list operations, this patch renames from the former to the later. The `reply_to` property indicates the queue that will handle the reply and the `correlation_id` is used to associate the reply with the request did by the application.

More details can be seen in the RabbitMQ [documentation](https://www.rabbitmq.com/tutorials/tutorial-six-python.html).

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin 18.0.0
- Go version: 1.14