### PR TITLE
fix: amqp: Get RPC infos from message properties

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -171,8 +171,6 @@ Event-command to list the registered things. It follows the request/reply patter
   <summary>Headers</summary>
 
   - `token` **String** user's token
-  - `reply_to` **String** reply's queue name
-  - `correlation_id` **String** ID to correlate reply-request after message arrived in the queue
 
 </details>
 
@@ -200,7 +198,9 @@ Event-command to list the registered things. It follows the request/reply patter
     - Name: device
     - Durable: `true`
     - Auto-delete: `false`
-  - Routing key: `reply_to`
+  - Routing key: `device.list`
+  - Reply To: <queueName> reply's queue name
+  - Correlation Id: <corrID> ID to correlate reply-request after message arrived in the queue
 
 </details>
 
@@ -212,8 +212,6 @@ Event-command to verify if a thing is authenticated based on its credentials. It
   <summary>Headers</summary>
 
   - `token` **String** user's token
-  - `reply_to` **String** reply's queue name
-  - `correlation_id` **String** ID to correlate reply-request after message arrived in the queue
 
 </details>
 
@@ -243,7 +241,9 @@ Event-command to verify if a thing is authenticated based on its credentials. It
     - Name: device
     - Durable: `true`
     - Auto-delete: `false`
-  - Routing key: `reply_to`
+  - Routing key: `device.auth`
+  - Reply To: <queueName> reply's queue name
+  - Correlation Id: <corrID> ID to correlate reply-request after message arrived in the queue
 
 </details>
 

--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -18,10 +18,12 @@ type Amqp struct {
 
 // InMsg represents the message received from the AMQP broker
 type InMsg struct {
-	Exchange   string
-	RoutingKey string
-	Headers    map[string]interface{}
-	Body       []byte
+	Exchange      string
+	RoutingKey    string
+	ReplyTo       string
+	CorrelationId string
+	Headers       map[string]interface{}
+	Body          []byte
 }
 
 // NewAmqp constructs the AMQP connection handler
@@ -196,6 +198,6 @@ func (a *Amqp) declareQueue(name string) error {
 
 func convertDeliveryToInMsg(deliveries <-chan amqp.Delivery, outMsg chan InMsg) {
 	for d := range deliveries {
-		outMsg <- InMsg{d.Exchange, d.RoutingKey, d.Headers, d.Body}
+		outMsg <- InMsg{d.Exchange, d.RoutingKey, d.ReplyTo, d.CorrelationId, d.Headers, d.Body}
 	}
 }

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -138,21 +138,11 @@ func (mc *MsgHandler) handleClientMessages(msg network.InMsg, token string) erro
 }
 
 func (mc *MsgHandler) handleRequestReplyCommands(msg network.InMsg, token string) error {
-	replyTo, ok := msg.Headers["reply_to"].(string)
-	if !ok {
-		return errors.New("reply_to property not provided")
-	}
-
-	corrID, ok := msg.Headers["correlation_id"].(string)
-	if !ok {
-		return errors.New("correlation_id property not provided")
-	}
-
 	switch msg.RoutingKey {
 	case bindingKeyAuthDevice:
-		return mc.thingController.AuthDevice(msg.Body, token, replyTo, corrID)
+		return mc.thingController.AuthDevice(msg.Body, token, msg.ReplyTo, msg.CorrelationId)
 	case bindingKeyListDevices:
-		return mc.thingController.ListDevices(token, replyTo, corrID)
+		return mc.thingController.ListDevices(token, msg.ReplyTo, msg.CorrelationId)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** (if necessary, link currently open issues with [special keywords](https://help.github.com/en/articles/closing-issues-using-keywords))
Get the Reply To and Correlation ID from the message properties instead
of using the header content. Before that, the BabelTower received Auth
and List messages but can't handle properly, because it didn't access
the RPC content correctly.
Also, fix the events.md with the correct information about this change.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform:
- Go version:

If you have relevant logs, error output and etc, please attach them.

**Other information:**
