### PR TITLE
amqp: Add expiration time to publish data messages

### DIFF
--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -32,6 +32,7 @@ type InMsg struct {
 type MessageOptions struct {
 	Authorization string
 	CorrelationID string
+	Expiration    string
 }
 
 // NewAmqp constructs the AMQP connection handler
@@ -68,13 +69,14 @@ func (a *Amqp) Stop() {
 // PublishPersistentMessage sends a persistent message to RabbitMQ
 func (a *Amqp) PublishPersistentMessage(exchange, exchangeType, key string, msg MessageSerializer, options *MessageOptions) error {
 	var headers map[string]interface{}
-	var corrID string
+	var corrID, expTime string
 
 	if options != nil {
 		headers = map[string]interface{}{
 			"Authorization": options.Authorization,
 		}
 		corrID = options.CorrelationID
+		expTime = options.Expiration
 	}
 
 	body, err := msg.Serialize()
@@ -100,6 +102,7 @@ func (a *Amqp) PublishPersistentMessage(exchange, exchangeType, key string, msg 
 			Priority:        0,
 			CorrelationId:   corrID,
 			Body:            body,
+			Expiration:      expTime,
 		},
 	)
 	if err != nil {

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -16,6 +16,7 @@ const (
 	schemaOutKey              = "device.schema.updated"
 	updateDataKey             = "data.update"
 	requestDataKey            = "data.request"
+	dataExpirationTime        = "86400000" // 1 day in milliseconds
 )
 
 // Publisher provides methods to send events to the clients
@@ -125,7 +126,7 @@ func (cs *commandSender) SendListResponse(things []*entities.Thing, replyTo, cor
 func (mp *msgClientPublisher) PublishPublishedData(thingID, token string, data []entities.Data) error {
 	mp.logger.Debug("sending publish data request")
 	msg := network.NewMessage(network.DataSent{ID: thingID, Data: data})
-	options := &network.MessageOptions{Authorization: token}
+	options := &network.MessageOptions{Authorization: token, Expiration: dataExpirationTime}
 
 	return mp.amqp.PublishPersistentMessage(exchangeDataPublished, exchangeDataPublishedType, "", msg, options)
 }


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:**

This patch adds an expiration time to publish data messages. The initial time I propose is exactly one day so that the platform's user can sync the data sent with the cloud. Otherwise, the data will be lost considering our limitations when running on the Fog layer.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOs Darwin - 18.0.0
- Go version: 1.14

