### PR TITLE
logger: Enable syslog via unix socket

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ func monitorSignals(sigs chan os.Signal, quit chan bool, logger logging.Logger) 
 
 func main() {
 	config := config.Load()
-	logrus := logging.NewLogrus(config.Logger.Level)
+	logrus := logging.NewLogrus(config.Logger.Level, config.Logger.Syslog)
 
 	logger := logrus.Get("Main")
 	logger.Info("starting KNoT Babeltower")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,8 @@ type Server struct {
 
 // Logger represents the logger configuration properties
 type Logger struct {
-	Level string
+	Level  string
+	Syslog bool
 }
 
 // Users represents the users service to proxy request
@@ -53,7 +54,7 @@ type Config struct {
 }
 
 func readFile(name string) {
-	logger := logging.NewLogrus("error").Get("Config")
+	logger := logging.NewLogrus("error", false).Get("Config")
 	viper.SetConfigName(name)
 	if err := viper.ReadInConfig(); err != nil {
 		logger.Fatalf("error reading config file, %s", err)
@@ -63,7 +64,7 @@ func readFile(name string) {
 // Load returns the service configuration
 func Load() Config {
 	var configuration Config
-	logger := logging.NewLogrus("error").Get("Config")
+	logger := logging.NewLogrus("error", false).Get("Config")
 	viper.AddConfigPath("internal/config")
 	viper.SetConfigType("yaml")
 

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -3,6 +3,7 @@ server:
 
 logger:
   level: info
+  syslog: false
 
 users:
   hostname: localhost

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -3,6 +3,7 @@ server:
 
 logger:
   level: debug
+  syslog: false
 
 users:
   hostname: users

--- a/pkg/logging/logrus.go
+++ b/pkg/logging/logrus.go
@@ -1,19 +1,22 @@
 package logging
 
 import (
+	"log/syslog"
 	"os"
 
 	"github.com/sirupsen/logrus"
+	logrus_syslog "github.com/sirupsen/logrus/hooks/syslog"
 )
 
 // Logrus represents the logrus logger
 type Logrus struct {
-	level string
+	level  string
+	syslog bool
 }
 
 // NewLogrus creates a new logrus instance
-func NewLogrus(level string) *Logrus {
-	return &Logrus{level: level}
+func NewLogrus(level string, syslog bool) *Logrus {
+	return &Logrus{level: level, syslog: syslog}
 }
 
 // Get returns a logrus instance based on the specific context
@@ -27,9 +30,27 @@ func (l *Logrus) Get(context string) *logrus.Entry {
 		TimestampFormat: "2006-01-02 15:04:05",
 	})
 
+	if l.syslog {
+		setupSyslog(log)
+	}
+
 	logger := log.WithFields(logrus.Fields{
 		"Context": context,
 	})
 
 	return logger
+}
+
+func setupSyslog(log *logrus.Logger) {
+	hook, err := logrus_syslog.NewSyslogHook("", "", syslog.LOG_INFO, "babeltower")
+	if err != nil {
+		log.Error("Unable to connect to local syslog daemon")
+		return
+	}
+
+	log.AddHook(hook)
+	log.SetFormatter(&logrus.TextFormatter{
+		DisableColors: true,
+		FullTimestamp: false,
+	})
 }


### PR DESCRIPTION
**Describe what this PR introduces:**

In order to facilitate the service monitoring when running on the RPi this patch enables redirecting logs to the syslog via unix socket protocol.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin 18.0.0
- Go version: 1.14

If you have relevant logs, error output and etc, please attach them.

**Other information:**
