### PR TITLE
thing: Add token to unregistered event

### DIFF
--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -22,7 +22,7 @@ const (
 // Publisher provides methods to send events to the clients
 type Publisher interface {
 	PublishRegisteredDevice(thingID, name, token string, err error) error
-	PublishUnregisteredDevice(thingID string, err error) error
+	PublishUnregisteredDevice(thingID, token string, err error) error
 	PublishUpdatedSchema(thingID string, schema []entities.Schema, err error) error
 	PublishUpdateData(thingID string, data []entities.Data) error
 	PublishRequestData(thingID string, sensorIds []int) error
@@ -67,12 +67,13 @@ func (mp *msgClientPublisher) PublishRegisteredDevice(thingID, name, token strin
 }
 
 // PublishUnregisteredDevice publishes the unregistered device's id and error message to the device unregistered queue
-func (mp *msgClientPublisher) PublishUnregisteredDevice(thingID string, err error) error {
+func (mp *msgClientPublisher) PublishUnregisteredDevice(thingID, token string, err error) error {
 	mp.logger.Debug("sending unregistered response")
 	errMsg := getErrMsg(err)
 	msg := network.NewMessage(network.DeviceUnregisteredResponse{ID: thingID, Error: errMsg})
+	options := &network.MessageOptions{Authorization: token}
 
-	return mp.amqp.PublishPersistentMessage(exchangeDevice, exchangeDeviceType, unregisterOutKey, msg, nil)
+	return mp.amqp.PublishPersistentMessage(exchangeDevice, exchangeDeviceType, unregisterOutKey, msg, options)
 }
 
 // PublishUpdatedSchema sends the updated schema response

--- a/pkg/thing/interactors/unregister_thing.go
+++ b/pkg/thing/interactors/unregister_thing.go
@@ -14,7 +14,7 @@ func (i *ThingInteractor) Unregister(authorization, id string) error {
 
 	err := i.thingProxy.Remove(authorization, id)
 	if err != nil {
-		sendErr := i.publisher.PublishUnregisteredDevice(id, err)
+		sendErr := i.publisher.PublishUnregisteredDevice(id, authorization, err)
 		if sendErr != nil {
 			i.logger.Debug(err)
 			return sendErr
@@ -22,7 +22,7 @@ func (i *ThingInteractor) Unregister(authorization, id string) error {
 		return err
 	}
 
-	sendErr := i.publisher.PublishUnregisteredDevice(id, nil)
+	sendErr := i.publisher.PublishUnregisteredDevice(id, authorization, nil)
 	if sendErr != nil {
 		return sendErr
 	}


### PR DESCRIPTION
**Describe what this PR introduces:**

This PR adds the authorization token as a header when sending 'device.unregistered' events so that consumers can operate based on that.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS Darwin 18.0.0
- Go version: 1.14