### PR TITLE
Add update config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,7 +58,7 @@ func main() {
 	thingInteractor := thingInteractors.NewThingInteractor(logrus.Get("ThingInteractor"), clientPublisher, thingProxy)
 
 	// Controllers
-	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor, commandSender)
+	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor, commandSender, clientPublisher)
 	userController := userControllers.NewUserController(logrus.Get("UserController"), createUser, createToken)
 
 	// Server

--- a/docs/events.md
+++ b/docs/events.md
@@ -8,6 +8,7 @@ This document describes the events `babeltower` is able to receive and send. The
   - [device.register](#device-register)
   - [device.unregister](#device-unregister)
   - [device.schema.sent](#device-schema-sent)
+  - [device.config.sent](#device-config-sent)
   - [device.list](#device-list)
   - [device.auth](#device-auth)
   - [data.sent](#data-sent)
@@ -18,6 +19,7 @@ This document describes the events `babeltower` is able to receive and send. The
   - [device.registered](#device-registered)
   - [device.unregistered](#device-unregistered)
   - [device.schema.updated](#device-schema-updated)
+  - [device.config.updated](#device-config-updated)
   - [data.published](#data-published)
   - [device.[id].data.request](#device-<id>-data-request)
   - [device.[id].data.update](#device-<id>-data-update)
@@ -162,6 +164,59 @@ Event that represents a device sending its schema to the services that are inter
   - Routing key: device.schema.sent
 
 </details>
+
+### **device.config.sent** <a name="device-config-sent"></a>
+
+Event that represents a device sending its config to the services that are interested. After receiving this event, `babeltower` updates the thing's config on the registry and send a [`device.config.updated`](#device-config-updated) event.
+
+<details>
+  <summary>Headers</summary>
+
+  - `token` **String** user's token
+
+</details>
+
+<details>
+  <summary>Payload</summary>
+
+  JSON in the following format:
+
+  - `id` **String** thing's ID
+  - `config` **Array** config items, each one formed by:
+    - `sensorId` **Number** sensor ID
+    - `change` **Boolean** enable sending sensor data when its value changes
+    - `timeSec` **Number** time interval in seconds that indicates when data must be sent to the cloud
+    - `lowerThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's lower than this threshold
+    - `upperThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's upper than this threshold
+
+  Example:
+
+  ```json
+  {
+    "id": "fbe64efa6c7f717e",
+    "config": [{
+      "sensorId": 1,
+      "change": true,
+      "timeSec": 10,
+      "lowerThreshold": 1000,
+      "upperThreshold": 3000
+    }]
+  }
+  ```
+</details>
+
+<details>
+  <summary>AMQP Binding</summary>
+
+  - Exchange:
+    - Type: direct
+    - Name: device
+    - Durable: `true`
+    - Auto-delete: `false`
+  - Routing key: device.config.sent
+
+</details>
+
 
 ### **device.list** <a name="device-list"></a>
 
@@ -496,6 +551,16 @@ Event that represents a thing's schema was updated.
   ```json
   {
     "id": "fbe64efa6c7f717e",
+    "schema": {
+      "id": "fbe64efa6c7f717e",
+      "schema": [{
+        "sensorId": 1,
+        "typeId": 0xFFF1,
+        "valueType": 3,
+        "unit": 0,
+        "name": "Door lock"
+      }]
+    },
     "error": null
   }
   ```
@@ -519,6 +584,62 @@ Event that represents a thing's schema was updated.
     - Durable: `true`
     - Auto-delete: `false`
   - Routing key: device.schema.updated
+
+</details>
+
+### **device.config.updated** <a name="device-config-updated"></a>
+
+Event that represents a thing's config was updated.
+
+<details>
+  <summary>Payload</summary>
+
+  JSON in the following format:
+
+  - `id` **String** thing's ID
+  - `config` **Array** list of updated config
+    - `sensorId` **Number** sensor ID
+    - `change` **Boolean** enable sending sensor data when its value changes
+    - `timeSec` **Number** time interval in seconds that indicates when data must be sent to the cloud
+    - `lowerThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's lower than this threshold
+    - `upperThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's upper than this threshold
+  - `error` **String** a string with detailed error message
+
+  Success example:
+
+  ```json
+  {
+    "id": "fbe64efa6c7f717e",
+    "config": [{
+      "sensorId": 1,
+      "change": true,
+      "timeSec": 10,
+      "lowerThreshold": 1000,
+      "upperThreshold": 3000
+    }],
+    "error": null
+  }
+  ```
+
+  Error example:
+
+  ```json
+  {
+    "id": "3aa21010cda96fe9",
+    "error": "invalid config"
+  }
+  ```
+</details>
+
+<details>
+  <summary>AMQP Binding</summary>
+
+  - Exchange:
+    - Type: direct
+    - Name: device
+    - Durable: `true`
+    - Auto-delete: `false`
+  - Routing key: device.config.updated
 
 </details>
 

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -21,7 +21,7 @@ func (fp *FakePublisher) PublishRegisteredDevice(thingID, name, token string, er
 }
 
 // PublishUnregisteredDevice provides a mock function to send an unregister device response
-func (fp *FakePublisher) PublishUnregisteredDevice(thingID string, err error) error {
+func (fp *FakePublisher) PublishUnregisteredDevice(thingID, token string, err error) error {
 	ret := fp.Called(thingID, err)
 	return ret.Error(0)
 }

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -32,6 +32,12 @@ func (fp *FakePublisher) PublishUpdatedSchema(thingID string, schema []entities.
 	return ret.Error(0)
 }
 
+// PublishUpdatedConfig provides a mock function to send an update config response
+func (fp *FakePublisher) PublishUpdatedConfig(thingID string, config []entities.Config, err error) error {
+	ret := fp.Called(thingID, config, err)
+	return ret.Error(0)
+}
+
 // PublishUpdateData provides a mock function to send an update data command
 func (fp *FakePublisher) PublishUpdateData(thingID string, data []entities.Data) error {
 	args := fp.Called(thingID, data)

--- a/pkg/mocks/thing_proxy.go
+++ b/pkg/mocks/thing_proxy.go
@@ -25,6 +25,12 @@ func (ftp *FakeThingProxy) UpdateSchema(authorization, thingID string, schema []
 	return ret.Error(0)
 }
 
+// UpdateConfig provides a mock function to update thing's config on the thing's service
+func (ftp *FakeThingProxy) UpdateConfig(authorization, thingID string, config []entities.Config) error {
+	ret := ftp.Called(authorization, thingID, config)
+	return ret.Error(0)
+}
+
 // Get provides a mock function to receive a thing from the thing's service
 func (ftp *FakeThingProxy) Get(authorization, thingID string) (*entities.Thing, error) {
 	args := ftp.Called(authorization, thingID)

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -55,6 +55,12 @@ type SchemaUpdatedResponse struct {
 	Error  *string           `json:"error"`
 }
 
+// ConfigUpdateRequest represents the incoming update config request message
+type ConfigUpdateRequest struct {
+	ID     string            `json:"id"`
+	Config []entities.Config `json:"config,omitempty"`
+}
+
 // DeviceAuthRequest represents the incoming auth device command
 type DeviceAuthRequest struct {
 	ID    string `json:"id"`

--- a/pkg/network/msg.go
+++ b/pkg/network/msg.go
@@ -61,6 +61,13 @@ type ConfigUpdateRequest struct {
 	Config []entities.Config `json:"config,omitempty"`
 }
 
+// ConfigUpdatedResponse represents the outgoing update config response message
+type ConfigUpdatedResponse struct {
+	ID     string            `json:"id"`
+	Config []entities.Config `json:"config,omitempty"`
+	Error  *string           `json:"error"`
+}
+
 // DeviceAuthRequest represents the incoming auth device command
 type DeviceAuthRequest struct {
 	ID    string `json:"id"`

--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -26,6 +26,7 @@ const (
 	bindingKeyRequestData      = "data.request"
 	bindingKeyUpdateData       = "data.update"
 	bindingKeySchemaSent       = "device.schema.sent"
+	bindingKeyConfigSent       = "device.config.sent"
 	bindingKeyEmpty            = ""
 )
 
@@ -77,6 +78,7 @@ func (mc *MsgHandler) subscribeToMessages(msgChan chan network.InMsg) error {
 	subscribe(msgChan, queueNameCommands, exchangeDevices, exchangeDevicesType, bindingKeyRequestData)
 	subscribe(msgChan, queueNameCommands, exchangeDevices, exchangeDevicesType, bindingKeyUpdateData)
 	subscribe(msgChan, queueNameCommands, exchangeDevices, exchangeDevicesType, bindingKeySchemaSent)
+	subscribe(msgChan, queueNameCommands, exchangeDevices, exchangeDevicesType, bindingKeyConfigSent)
 
 	// Subscribe to request-reply messages received from any client
 	subscribe(msgChan, queueNameCommands, exchangeDevices, exchangeDevicesType, bindingKeyAuthDevice)
@@ -128,6 +130,8 @@ func (mc *MsgHandler) handleClientMessages(msg network.InMsg, token string) erro
 		return mc.thingController.Unregister(msg.Body, token)
 	case bindingKeySchemaSent:
 		return mc.thingController.UpdateSchema(msg.Body, token)
+	case bindingKeyConfigSent:
+		return mc.thingController.UpdateConfig(msg.Body, token)
 	case bindingKeyRequestData:
 		return mc.thingController.RequestData(msg.Body, token)
 	case bindingKeyUpdateData:

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -67,8 +67,23 @@ func (mc *ThingController) UpdateSchema(body []byte, authorizationHeader string)
 
 // UpdateConfig handles the update config request and execute its use case
 func (mc *ThingController) UpdateConfig(body []byte, authorizationHeader string) error {
-	// TODO: Call updateConfig interactor
+	var updateConfigReq network.ConfigUpdateRequest
+	err := json.Unmarshal(body, &updateConfigReq)
+	if err != nil {
+		mc.logger.Error(err)
+		return err
+	}
+
+	mc.logger.Info("update config message received")
+	mc.logger.Debug(authorizationHeader, updateConfigReq)
+
+	err = mc.thingInteractor.UpdateConfig(authorizationHeader, updateConfigReq.ID, updateConfigReq.Config)
+	if err != nil {
+		return err
+	}
+
 	// TODO: Publish response to message broker
+
 	return nil
 }
 

--- a/pkg/thing/controllers/thing.go
+++ b/pkg/thing/controllers/thing.go
@@ -65,6 +65,13 @@ func (mc *ThingController) UpdateSchema(body []byte, authorizationHeader string)
 	return nil
 }
 
+// UpdateConfig handles the update config request and execute its use case
+func (mc *ThingController) UpdateConfig(body []byte, authorizationHeader string) error {
+	// TODO: Call updateConfig interactor
+	// TODO: Publish response to message broker
+	return nil
+}
+
 // ListDevices handles the list devices request and execute its use case
 func (mc *ThingController) ListDevices(authorization, replyTo, corrID string) error {
 	mc.logger.Info("list devices command received")

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -14,6 +14,7 @@ const (
 	registerOutKey            = "device.registered"
 	unregisterOutKey          = "device.unregistered"
 	schemaOutKey              = "device.schema.updated"
+	configOutKey              = "device.config.updated"
 	updateDataKey             = "data.update"
 	requestDataKey            = "data.request"
 	dataExpirationTime        = "86400000" // 1 day in milliseconds
@@ -24,6 +25,7 @@ type Publisher interface {
 	PublishRegisteredDevice(thingID, name, token string, err error) error
 	PublishUnregisteredDevice(thingID, token string, err error) error
 	PublishUpdatedSchema(thingID string, schema []entities.Schema, err error) error
+	PublishUpdatedConfig(thingID string, config []entities.Config, err error) error
 	PublishUpdateData(thingID string, data []entities.Data) error
 	PublishRequestData(thingID string, sensorIds []int) error
 	PublishPublishedData(thingID, token string, data []entities.Data) error
@@ -83,6 +85,15 @@ func (mp *msgClientPublisher) PublishUpdatedSchema(thingID string, schema []enti
 	msg := network.NewMessage(network.SchemaUpdatedResponse{ID: thingID, Schema: schema, Error: errMsg})
 
 	return mp.amqp.PublishPersistentMessage(exchangeDevice, exchangeDeviceType, schemaOutKey, msg, nil)
+}
+
+// PublishUpdatedConfig sends the updated config response
+func (mp *msgClientPublisher) PublishUpdatedConfig(thingID string, config []entities.Config, err error) error {
+	mp.logger.Debug("sending update config response")
+	errMsg := getErrMsg(err)
+	msg := network.NewMessage(network.ConfigUpdatedResponse{ID: thingID, Config: config, Error: errMsg})
+
+	return mp.amqp.PublishPersistentMessage(exchangeDevice, exchangeDeviceType, configOutKey, msg, nil)
 }
 
 // PublishRequestData sends request data command

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -212,7 +212,7 @@ func (p proxy) Get(authorization, ID string) (*entities.Thing, error) {
 	for i := range things {
 		t := things[i]
 		if t.Metadata.Knot.ID == ID {
-			nt := &entities.Thing{ID: ID, Token: t.ID, Name: t.Name, Schema: t.Metadata.Knot.Schema}
+			nt := &entities.Thing{ID: ID, Token: t.ID, Name: t.Name, Schema: t.Metadata.Knot.Schema, Config: t.Metadata.Knot.Config}
 			return nt, nil
 		}
 	}

--- a/pkg/thing/entities/config.go
+++ b/pkg/thing/entities/config.go
@@ -1,0 +1,10 @@
+package entities
+
+// Config represents the thing's config
+type Config struct {
+	SensorID       int
+	Change         bool
+	TimeSec        int
+	LowerThreshold int
+	UpperThreshold int
+}

--- a/pkg/thing/entities/config.go
+++ b/pkg/thing/entities/config.go
@@ -2,9 +2,9 @@ package entities
 
 // Config represents the thing's config
 type Config struct {
-	SensorID       int
-	Change         bool
-	TimeSec        int
-	LowerThreshold int
-	UpperThreshold int
+	SensorID       int         `json:"sensorId"`
+	Change         bool        `json:"change"`
+	TimeSec        int         `json:"timeSec"`
+	LowerThreshold interface{} `json:"lowerThreshold,omitempty"`
+	UpperThreshold interface{} `json:"upperThreshold,omitempty"`
 }

--- a/pkg/thing/entities/thing.go
+++ b/pkg/thing/entities/thing.go
@@ -6,4 +6,5 @@ type Thing struct {
 	Token  string   `json:"token,omitempty"`
 	Name   string   `json:"name,omitempty"`
 	Schema []Schema `json:"schema,omitempty"`
+	Config []Config `json:"config,omitempty"`
 }

--- a/pkg/thing/interactors/errors.go
+++ b/pkg/thing/interactors/errors.go
@@ -38,4 +38,10 @@ var (
 
 	// ErrDataInvalid is returned when the provided data mismatch the thing's schema
 	ErrDataInvalid = errors.New("data is incompatible with thing's schema")
+
+	// ErrConfigNotProvided is returned when thing's config is not provided
+	ErrConfigNotProvided = errors.New("thing's config not provided")
+
+	// ErrConfigInvalid is returned when thing's config mismatch the thing's schema
+	ErrConfigInvalid = errors.New("config is incompatible with thing's schema")
 )

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -12,6 +12,7 @@ type Interactor interface {
 	Register(authorization, id, name string) error
 	Unregister(authorization, id string) error
 	UpdateSchema(authorization, id string, schemaList []entities.Schema) error
+	UpdateConfig(authorization, id string, configList []entities.Config) error
 	List(authorization string) ([]*entities.Thing, error)
 	RequestData(authorization, thingID string, sensorIds []int) error
 	UpdateData(authorization, thingID string, data []entities.Data) error

--- a/pkg/thing/interactors/update_config.go
+++ b/pkg/thing/interactors/update_config.go
@@ -1,0 +1,62 @@
+package interactors
+
+import (
+	"fmt"
+
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+)
+
+// UpdateConfig executes the use case to update thing's configuration
+func (i *ThingInteractor) UpdateConfig(authorization, id string, configList []entities.Config) error {
+	if authorization == "" {
+		return ErrAuthNotProvided
+	}
+	if id == "" {
+		return ErrIDNotProvided
+	}
+	if configList == nil {
+		return ErrConfigNotProvided
+	}
+
+	err := i.validateConfig(authorization, id, configList)
+	if err != nil {
+		return fmt.Errorf("failed to validate if config is valid: %w", err)
+	}
+
+	err = i.thingProxy.UpdateConfig(authorization, id, configList)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (i *ThingInteractor) validateConfig(authorization, id string, configList []entities.Config) error {
+	thing, err := i.thingProxy.Get(authorization, id)
+	if err != nil {
+		return fmt.Errorf("error getting thing metadata: %w", err)
+	}
+
+	if thing.Schema == nil {
+		return ErrSchemaUndefined
+	}
+
+	for _, c := range configList {
+		schema := checkSensorInSchema(c.SensorID, thing.Schema)
+		if schema == nil {
+			return ErrConfigInvalid
+		}
+	}
+
+	return nil
+}
+
+func checkSensorInSchema(sensorID int, schemaList []entities.Schema) *entities.Schema {
+	for _, s := range schemaList {
+		if sensorID == s.SensorID {
+			return &s
+		}
+	}
+
+	return nil
+}

--- a/pkg/thing/interactors/update_config_test.go
+++ b/pkg/thing/interactors/update_config_test.go
@@ -1,0 +1,161 @@
+package interactors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CESARBR/knot-babeltower/pkg/mocks"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
+	"github.com/stretchr/testify/assert"
+)
+
+type UpdateConfigTestCase struct {
+	name           string
+	authParam      string
+	idParam        string
+	configParam    []entities.Config
+	expectedError  error
+	fakeLogger     *mocks.FakeLogger
+	fakeThingProxy *mocks.FakeThingProxy
+	fakePublisher  *mocks.FakePublisher
+}
+
+var configExample = []entities.Config{
+	{
+		SensorID:       0,
+		Change:         true,
+		TimeSec:        12,
+		LowerThreshold: 1000,
+		UpperThreshold: 2000,
+	},
+}
+
+var (
+	errProxyUpdateConfig = errors.New("can't update config on thing's service")
+)
+
+var updateConfigTestCases = []UpdateConfigTestCase{
+	{
+		"authorization token not provided",
+		"",
+		"c09660af89ecba61",
+		[]entities.Config{{}},
+		ErrAuthNotProvided,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"thing id not provided",
+		"authorization-token",
+		"",
+		[]entities.Config{{}},
+		ErrIDNotProvided,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"thing's config not provided",
+		"authorization-token",
+		"c09660af89ecba61",
+		nil,
+		ErrConfigNotProvided,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{},
+		&mocks.FakePublisher{},
+	},
+	{
+		"thing's config successfully updated on the thing's proxy",
+		"authorization-token",
+		"c09660af89ecba61",
+		configExample,
+		nil,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}, ReturnErr: nil},
+		&mocks.FakePublisher{},
+	},
+	{
+		"failed to update thing's config on the thing's proxy",
+		"authorization-token",
+		"c09660af89ecba61",
+		configExample,
+		errProxyUpdateConfig,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errProxyUpdateConfig},
+		&mocks.FakePublisher{},
+	},
+	{
+		"failed get thing's metadata on the thing's proxy",
+		"authorization-token",
+		"c09660af89ecba61",
+		configExample,
+		errProxyUpdateConfig,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{ReturnErr: errProxyUpdateConfig},
+		&mocks.FakePublisher{},
+	},
+	{
+		"failed to updade thing's config if it doesn't have schema yet",
+		"authorization-token",
+		"c09660af89ecba61",
+		configExample,
+		ErrSchemaUndefined,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:    "thing-id",
+			Token: "thing-token",
+			Name:  "thing",
+		}},
+		&mocks.FakePublisher{},
+	},
+	{
+		"failed to updade thing's config if incompatible with schema",
+		"authorization-token",
+		"c09660af89ecba61",
+		[]entities.Config{
+			{
+				SensorID:       1,
+				Change:         true,
+				TimeSec:        12,
+				LowerThreshold: 1000,
+				UpperThreshold: 2000,
+			},
+		},
+		ErrConfigInvalid,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: voltageSchema,
+		}},
+		&mocks.FakePublisher{},
+	},
+}
+
+func TestUpdateConfig(t *testing.T) {
+	for _, tc := range updateConfigTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.fakeThingProxy.
+				On("Get", tc.authParam, tc.idParam).
+				Return(tc.fakeThingProxy.Thing, tc.fakeThingProxy.ReturnErr).
+				Maybe()
+			tc.fakeThingProxy.
+				On("UpdateConfig", tc.authParam, tc.idParam, tc.configParam).
+				Return(tc.fakeThingProxy.ReturnErr).
+				Maybe()
+
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy)
+			err := thingInteractor.UpdateConfig(tc.authParam, tc.idParam, tc.configParam)
+
+			assert.EqualValues(t, errors.Is(err, tc.expectedError), true)
+			tc.fakeThingProxy.AssertExpectations(t)
+		})
+	}
+}

--- a/pkg/thing/interactors/update_data.go
+++ b/pkg/thing/interactors/update_data.go
@@ -58,7 +58,7 @@ func validateSchema(data entities.Data, schema []entities.Schema) bool {
 			switch data.Value.(type) {
 			case float64:
 				if data.Value == math.Trunc(data.Value.(float64)) { // check if number is integer
-					return validateSchemaNumber(data.Value.(float64), s.ValueType)
+					return ValidateSchemaNumber(data.Value.(float64), s.ValueType)
 				}
 				return s.ValueType == 2 // float
 			case bool:
@@ -74,12 +74,13 @@ func validateSchema(data entities.Data, schema []entities.Schema) bool {
 	return false
 }
 
-func validateSchemaNumber(value float64, valueType int) bool {
+// ValidateSchemaNumber validates the value received against its type defined in the sensor's schema
+func ValidateSchemaNumber(value float64, valueType int) bool {
 	switch valueType {
 	case 1: // int
 		return value >= math.MinInt32 && value <= math.MaxInt32
 	case 2: // float
-		return true;
+		return true
 	case 5: // int64
 		return value >= math.MinInt64 && value <= math.MaxInt64
 	case 6: // uint


### PR DESCRIPTION
**Describe what this PR introduces:**

This patch adds the ability to update the configuration of the data items owned by a KNoT Thing. This will be very useful to update the thing configuration remotely without needing to recreate it.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS - Darwin 18.0.0
- Go version: 1.14

