### PR TITLE
Add validation if config hasn't changed and make timeSec optional

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -185,7 +185,7 @@ Event that represents a device sending its config to the services that are inter
   - `config` **Array** config items, each one formed by:
     - `sensorId` **Number** sensor ID
     - `change` **Boolean** enable sending sensor data when its value changes
-    - `timeSec` **Number** time interval in seconds that indicates when data must be sent to the cloud
+    - `timeSec` **Number** - **Optional** time interval in seconds that indicates when data must be sent to the cloud
     - `lowerThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's lower than this threshold
     - `upperThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's upper than this threshold
 
@@ -600,7 +600,7 @@ Event that represents a thing's config was updated.
   - `config` **Array** list of updated config
     - `sensorId` **Number** sensor ID
     - `change` **Boolean** enable sending sensor data when its value changes
-    - `timeSec` **Number** time interval in seconds that indicates when data must be sent to the cloud
+    - `timeSec` **Number** - **Optional** time interval in seconds that indicates when data must be sent to the cloud
     - `lowerThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's lower than this threshold
     - `upperThreshold` **Optional (Depends on schema's valueType)** send data to the cloud if it's upper than this threshold
   - `error` **String** a string with detailed error message

--- a/pkg/thing/entities/config.go
+++ b/pkg/thing/entities/config.go
@@ -4,7 +4,7 @@ package entities
 type Config struct {
 	SensorID       int         `json:"sensorId"`
 	Change         bool        `json:"change"`
-	TimeSec        int         `json:"timeSec"`
+	TimeSec        int         `json:"timeSec,omitempty"`
 	LowerThreshold interface{} `json:"lowerThreshold,omitempty"`
 	UpperThreshold interface{} `json:"upperThreshold,omitempty"`
 }

--- a/pkg/thing/interactors/errors.go
+++ b/pkg/thing/interactors/errors.go
@@ -44,4 +44,7 @@ var (
 
 	// ErrConfigInvalid is returned when thing's config mismatch the thing's schema
 	ErrConfigInvalid = errors.New("config is incompatible with thing's schema")
+
+	// ErrConfigEqual is returned when thing's config already has the same config
+	ErrConfigEqual = errors.New("nothing to update in the thing's config")
 )

--- a/pkg/thing/interactors/update_config.go
+++ b/pkg/thing/interactors/update_config.go
@@ -3,6 +3,7 @@ package interactors
 import (
 	"fmt"
 	"math"
+	"reflect"
 
 	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 )
@@ -40,6 +41,10 @@ func (i *ThingInteractor) validateConfig(authorization, id string, configList []
 
 	if thing.Schema == nil {
 		return ErrSchemaUndefined
+	}
+
+	if reflect.DeepEqual(thing.Config, configList) {
+		return ErrConfigEqual
 	}
 
 	err = validateSchemaMatch(configList, thing.Schema)

--- a/pkg/thing/interactors/update_config_test.go
+++ b/pkg/thing/interactors/update_config_test.go
@@ -186,6 +186,22 @@ var updateConfigTestCases = []UpdateConfigTestCase{
 		}},
 		&mocks.FakePublisher{},
 	},
+	{
+		"failed to updade thing's config if it has not changed",
+		"authorization-token",
+		"c09660af89ecba61",
+		configExample,
+		ErrConfigEqual,
+		&mocks.FakeLogger{},
+		&mocks.FakeThingProxy{Thing: &entities.Thing{
+			ID:     "thing-id",
+			Token:  "thing-token",
+			Name:   "thing",
+			Schema: schemaExample,
+			Config: configExample,
+		}},
+		&mocks.FakePublisher{},
+	},
 }
 
 func TestUpdateConfig(t *testing.T) {


### PR DESCRIPTION
**Describe what this PR introduces:**

Two main changes:

- Validate if thing's config is already up to date;
- Make `timeSec` property optional.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: macOS 18.0.0
- Go version: 1.14
