### PR TITLE
Security fix (G104: Audit errors not checked)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,18 @@ on:
     branches: [ master ]
 
 jobs:
+  tests:
+    name: Gosec Security Check
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: ./...
   build:
     name: Build and Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 GOCMD=go
+GOSECCMD=gosec
 GOBUILD=$(GOCMD) build
 GOCLEAN=$(GOCMD) clean
 GOTEST=$(GOCMD) test -v ./...
@@ -21,6 +22,7 @@ tools:
 	go get github.com/ahmetb/govvv
 	go get github.com/cespare/reflex
 	go get github.com/swaggo/swag/cmd/swag
+	go get github.com/securego/gosec/v2/cmd/gosec
 	pip install pre-commit
 	pre-commit install
 
@@ -43,6 +45,10 @@ http-docs:
 .PHONY: test
 test:
 	set -o pipefail && $(GOTEST) | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/'' | grep -v RUN
+
+.PHONY: sectest
+sectest:
+	$(GOSECCMD) -fmt=json ./...
 
 .PHONY: lint
 lint:

--- a/pkg/network/amqp.go
+++ b/pkg/network/amqp.go
@@ -56,11 +56,11 @@ func (a *Amqp) Start(started chan bool) {
 // Stop closes the connection started
 func (a *Amqp) Stop() {
 	if a.conn != nil && !a.conn.IsClosed() {
-		a.conn.Close()
+		defer a.conn.Close()
 	}
 
 	if a.channel != nil {
-		a.channel.Close()
+		defer a.channel.Close()
 	}
 
 	a.logger.Debug("AMQP handler stopped")


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** 
This PR depends on : https://github.com/CESARBR/knot-babeltower/pull/96
This patch fixes a security error shown by the Gosec tool. ([G104](https://securego.io/docs/rules/g104.html)).
The error happens because the function "Stop()" (pkg/network/amqp.go, line 57) would and before the AMQP
connection could properly end.
**What kind of change does this PR introduce?** (check at least one)

- [x] Bug fix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

**Testing environment:**

- Operating System/Platform: Ubuntu 20.04.1 LTS
- Go version: go1.15.7 linux/amd64

If you have relevant logs, error output and etc, please attach them.

**Other information:**
