### PR TITLE
Update publish data to use session mechanism

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,7 +66,7 @@ func main() {
 	createToken := userInteractors.NewCreateToken(logrus.Get("CreateToken"), usersProxy, authnProxy)
 	createSession := userInteractors.NewCreateSession(thingProxy, generator, sessionStore)
 
-	thingInteractor := thingInteractors.NewThingInteractor(logrus.Get("ThingInteractor"), clientPublisher, thingProxy)
+	thingInteractor := thingInteractors.NewThingInteractor(logrus.Get("ThingInteractor"), clientPublisher, thingProxy, sessionStore)
 
 	// Controllers
 	thingController := thingControllers.NewThingController(logrus.Get("ThingController"), thingInteractor, commandSender, clientPublisher)

--- a/docs/events.md
+++ b/docs/events.md
@@ -19,6 +19,7 @@ This document describes the events `babeltower` is able to receive and send. The
   - [device.unregistered](#device-unregistered)
   - [device.config.updated](#device-config-updated)
   - [data.published](#data-published)
+  - [data.[sessionId].published](#data-session-published)
   - [device.[id].data.request](#device-<id>-data-request)
   - [device.[id].data.update](#device-<id>-data-update)
 
@@ -607,6 +608,50 @@ Event that represents a data published from a thing's sensor.
   - Exchange:
     - Type: fanout
     - Name: data.published
+    - Durable: `true`
+    - Auto-delete: `false`
+
+</details>
+
+### **data.[sessionId].published** <a name="data-session-published"></a>
+
+Event that represents a data published from a thing's sensor to a user session. You can obtain a `sessionId` by sending a request to the endpoint `POST /sessions` with a valid authorization token. The endpoint specification can be easily viewed in the browser by accessing the address `http://<address>:<port>/swagger/index.html`.
+
+<details>
+  <summary>Payload</summary>
+
+  JSON in the following format:
+
+  - `id` **String** thing's ID
+  - `data` **Array** data items to be published, each one formed by:
+    - `sensorId` **Number** sensor ID
+    - `value` **Number|Boolean|String** sensor value
+
+  Example:
+
+  ```json
+  {
+    "id": "fbe64efa6c7f717e",
+    "data": [
+      {
+        "sensorId": 1,
+        "value": false
+      },
+      {
+        "sensorId": 2,
+        "value": 1000
+      }
+    ]
+  }
+  ```
+</details>
+
+<details>
+  <summary>AMQP Binding</summary>
+
+  - Exchange:
+    - Type: fanout
+    - Name: data.[sessionId].published
     - Durable: `true`
     - Auto-delete: `false`
 

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -8,10 +8,11 @@ import (
 // FakePublisher represents a mocking type for the publisher service
 type FakePublisher struct {
 	mock.Mock
-	ReturnErr error
-	SendError error
-	Token     string
-	Err       error
+	PublishErr        error
+	PublishSessionErr error
+	SendError         error
+	Token             string
+	Err               error
 }
 
 // PublishRegisteredDevice provides a mock function to send a register device response

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -49,3 +49,9 @@ func (fp *FakePublisher) PublishBroadcastData(thingID, token string, data []enti
 	args := fp.Called(thingID, token, data)
 	return args.Error(0)
 }
+
+// PublishSessionData provides a mock function to send a request data command
+func (fp *FakePublisher) PublishSessionData(thingID, token, sessionID string, data []entities.Data) error {
+	args := fp.Called(thingID, token, sessionID, data)
+	return args.Error(0)
+}

--- a/pkg/mocks/publisher.go
+++ b/pkg/mocks/publisher.go
@@ -44,8 +44,8 @@ func (fp *FakePublisher) PublishRequestData(thingID string, sensorIds []int) err
 	return args.Error(0)
 }
 
-// PublishPublishedData provides a mock function to send a request data command
-func (fp *FakePublisher) PublishPublishedData(thingID, token string, data []entities.Data) error {
-	args := fp.Called(thingID, data)
+// PublishBroadcastData provides a mock function to publish data in broadcast mode
+func (fp *FakePublisher) PublishBroadcastData(thingID, token string, data []entities.Data) error {
+	args := fp.Called(thingID, token, data)
 	return args.Error(0)
 }

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -26,7 +26,9 @@ type Publisher interface {
 	PublishUpdatedConfig(thingID string, config []entities.Config, changed bool, err error) error
 	PublishUpdateData(thingID string, data []entities.Data) error
 	PublishRequestData(thingID string, sensorIds []int) error
-	PublishPublishedData(thingID, token string, data []entities.Data) error
+
+	// Publish data in broadcast mode to all clients within the cluster
+	PublishBroadcastData(thingID, token string, data []entities.Data) error
 }
 
 // Sender represents the operations to send commands response
@@ -123,9 +125,9 @@ func (cs *commandSender) SendListResponse(things []*entities.Thing, replyTo, cor
 	return cs.amqp.PublishPersistentMessage(exchangeDevice, exchangeDeviceType, replyTo, msg, options)
 }
 
-// PublishPublishedData send update data command
-func (mp *msgClientPublisher) PublishPublishedData(thingID, token string, data []entities.Data) error {
-	mp.logger.Debug("sending publish data request")
+// PublishBroadcastData publishes thing's data to all consumers
+func (mp *msgClientPublisher) PublishBroadcastData(thingID, token string, data []entities.Data) error {
+	mp.logger.Debug("publishing broadcast data")
 	msg := network.NewMessage(network.DataSent{ID: thingID, Data: data})
 	options := &network.MessageOptions{Authorization: token, Expiration: dataExpirationTime}
 

--- a/pkg/thing/interactors/auth_thing_test.go
+++ b/pkg/thing/interactors/auth_thing_test.go
@@ -72,7 +72,7 @@ func TestAuthThing(t *testing.T) {
 				Return(tc.fakeThingProxy.Thing, tc.fakeThingProxy.ReturnErr).
 				Maybe()
 
-			thingInteractor := NewThingInteractor(tc.fakeLogger, nil, tc.fakeThingProxy)
+			thingInteractor := NewThingInteractor(tc.fakeLogger, nil, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 			err := thingInteractor.Auth(tc.authParam, tc.idParam)
 
 			if tc.authParam == "" {

--- a/pkg/thing/interactors/interactor.go
+++ b/pkg/thing/interactors/interactor.go
@@ -1,6 +1,7 @@
 package interactors
 
 import (
+	"github.com/CESARBR/knot-babeltower/pkg/cache"
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
 	"github.com/CESARBR/knot-babeltower/pkg/thing/delivery/amqp"
 	"github.com/CESARBR/knot-babeltower/pkg/thing/delivery/http"
@@ -22,9 +23,10 @@ type Interactor interface {
 // ThingInteractor represents the thing interactor capabilities, it's composed
 // by the necessary dependencies
 type ThingInteractor struct {
-	logger     logging.Logger
-	publisher  amqp.Publisher
-	thingProxy http.ThingProxy
+	logger       logging.Logger
+	publisher    amqp.Publisher
+	thingProxy   http.ThingProxy
+	sessionStore cache.SessionStore
 }
 
 // NewThingInteractor creates a new ThingInteractor instance
@@ -32,6 +34,7 @@ func NewThingInteractor(
 	logger logging.Logger,
 	publisher amqp.Publisher,
 	thingProxy http.ThingProxy,
+	sessionStore cache.SessionStore,
 ) *ThingInteractor {
-	return &ThingInteractor{logger, publisher, thingProxy}
+	return &ThingInteractor{logger, publisher, thingProxy, sessionStore}
 }

--- a/pkg/thing/interactors/list_things_test.go
+++ b/pkg/thing/interactors/list_things_test.go
@@ -84,7 +84,7 @@ func TestListThings(t *testing.T) {
 				Return(tc.expectedProxyResponseThings, tc.expectedProxyResponseError).
 				Maybe()
 
-			thingInteractor := NewThingInteractor(tc.fakeLogger, nil, tc.fakeThingProxy)
+			thingInteractor := NewThingInteractor(tc.fakeLogger, nil, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 			things, err := thingInteractor.List(tc.authorization)
 			if tc.authorization == "" {
 				assert.EqualError(t, err, ErrAuthNotProvided.Error())

--- a/pkg/thing/interactors/publish_data.go
+++ b/pkg/thing/interactors/publish_data.go
@@ -23,9 +23,9 @@ func (i *ThingInteractor) PublishData(authorization, thingID string, data []enti
 		return fmt.Errorf("error validating thing's data: %w", err)
 	}
 
-	err = i.publisher.PublishPublishedData(thingID, authorization, data)
+	err = i.publisher.PublishBroadcastData(thingID, authorization, data)
 	if err != nil {
-		return fmt.Errorf("error sending message to client: %w", err)
+		return fmt.Errorf("error publishing data in broadcast mode: %w", err)
 	}
 
 	i.logger.Info("publish data message successfully sent")

--- a/pkg/thing/interactors/register_thing_test.go
+++ b/pkg/thing/interactors/register_thing_test.go
@@ -122,7 +122,7 @@ func TestRegisterThing(t *testing.T) {
 			tc.fakeThingProxy.On("Create", tc.idParam, tc.nameParam, tc.authParam).
 				Return(tc.fakePublisher.Token, tc.fakeThingProxy.CreateErr).Maybe()
 
-			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy)
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 			err := thingInteractor.Register(tc.authParam, tc.idParam, tc.nameParam)
 			if err != nil && !assert.IsType(t, errors.Unwrap(err), tc.errExpected) {
 				t.Errorf("create thing failed with unexpected error. Error: %s", err)

--- a/pkg/thing/interactors/register_thing_test.go
+++ b/pkg/thing/interactors/register_thing_test.go
@@ -96,7 +96,7 @@ var registerThingUseCases = []registerTestCase{
 		nil,
 		&mocks.FakeLogger{},
 		&mocks.FakeThingProxy{ReturnErr: entities.ErrThingNotFound},
-		&mocks.FakePublisher{ReturnErr: errRegisterResponse},
+		&mocks.FakePublisher{PublishErr: errRegisterResponse},
 	},
 	{
 		"register response successfully sent",
@@ -118,7 +118,7 @@ func TestRegisterThing(t *testing.T) {
 			tc.fakeThingProxy.On("Get", tc.authParam, tc.idParam).
 				Return(tc.thingExpected, tc.fakeThingProxy.ReturnErr).Maybe()
 			tc.fakePublisher.On("PublishRegisteredDevice", tc.idParam, tc.nameParam, tc.fakePublisher.Token, tc.fakePublisher.SendError).
-				Return(tc.fakePublisher.ReturnErr).Maybe()
+				Return(tc.fakePublisher.PublishErr).Maybe()
 			tc.fakeThingProxy.On("Create", tc.idParam, tc.nameParam, tc.authParam).
 				Return(tc.fakePublisher.Token, tc.fakeThingProxy.CreateErr).Maybe()
 

--- a/pkg/thing/interactors/request_data_test.go
+++ b/pkg/thing/interactors/request_data_test.go
@@ -206,7 +206,7 @@ func TestGetData(t *testing.T) {
 				Maybe()
 		})
 
-		thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy)
+		thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 		err := thingInteractor.RequestData(tc.authorization, tc.thingID, tc.sensorIds)
 		if tc.authorization == "" {
 			assert.EqualError(t, err, ErrAuthNotProvided.Error())

--- a/pkg/thing/interactors/unregister_thing_test.go
+++ b/pkg/thing/interactors/unregister_thing_test.go
@@ -108,7 +108,7 @@ func TestUnregisterThing(t *testing.T) {
 				Return(tc.fakePublisher.SendError).
 				Maybe()
 
-			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy)
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 			err := thingInteractor.Unregister(tc.authParam, tc.idParam)
 
 			if err != nil {

--- a/pkg/thing/interactors/update_config_test.go
+++ b/pkg/thing/interactors/update_config_test.go
@@ -371,7 +371,7 @@ func TestUpdateConfig(t *testing.T) {
 				Return(tc.fakeThingProxy.ReturnErr).
 				Maybe()
 
-			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy)
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 			changed, err := thingInteractor.UpdateConfig(tc.authParam, tc.idParam, tc.configParam)
 
 			assert.EqualValues(t, tc.expectedChanged, changed)

--- a/pkg/thing/interactors/update_data_test.go
+++ b/pkg/thing/interactors/update_data_test.go
@@ -165,7 +165,7 @@ func TestUpdateData(t *testing.T) {
 				Return(tc.fakePublisher.ReturnErr).
 				Maybe()
 
-			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy)
+			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, &mocks.FakeSessionStore{})
 			err := thingInteractor.UpdateData(tc.authParam, tc.idParam, tc.dataParam)
 
 			assert.EqualValues(t, errors.Is(err, tc.expectedError), true)

--- a/pkg/thing/interactors/update_data_test.go
+++ b/pkg/thing/interactors/update_data_test.go
@@ -133,7 +133,7 @@ var updateDataUseCases = []UpdateDataTestCase{
 			Name:   "thing",
 			Config: configWithVoltageSchema,
 		}},
-		&mocks.FakePublisher{ReturnErr: errClientSend},
+		&mocks.FakePublisher{PublishErr: errClientSend},
 		errClientSend,
 	},
 	{
@@ -162,7 +162,7 @@ func TestUpdateData(t *testing.T) {
 				Maybe()
 			tc.fakePublisher.
 				On("PublishUpdateData", tc.idParam, tc.dataParam).
-				Return(tc.fakePublisher.ReturnErr).
+				Return(tc.fakePublisher.PublishErr).
 				Maybe()
 
 			thingInteractor := NewThingInteractor(tc.fakeLogger, tc.fakePublisher, tc.fakeThingProxy, &mocks.FakeSessionStore{})


### PR DESCRIPTION
**Describe what this PR introduces:**

Along with #99 and #100, this MR updates the publish data operation to send data to specific user sessions based on a `sessionId`. This will enable the users to listen only to events sent by their own things.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [X] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [X] New/updated tests are included

**Testing environment:**

- Operating System/Platform: Ubuntu 18.04
- Go version: 1.16

If you have relevant logs, error output and etc, please attach them.

**Other information:**
