### PR TITLE
Make service compatible with Mainflux 0.12.1 version

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -55,7 +55,7 @@ func main() {
 
 	// Services
 	usersProxy := userDeliveryHTTP.NewUsersProxy(logrus.Get("UsersProxy"), config.Users.Hostname, config.Users.Port)
-	authnProxy := userDeliveryHTTP.NewAuthnProxy(logrus.Get("AuthnProxy"), config.Authn.Hostname, config.Authn.Port)
+	authProxy := userDeliveryHTTP.NewAuthProxy(logrus.Get("AuthProxy"), config.Auth.Hostname, config.Auth.Port)
 	thingProxy := thingDeliveryHTTP.NewThingProxy(logrus.Get("ThingProxy"), config.Things.Hostname, config.Things.Protocol, config.Things.Port)
 
 	// ID generator
@@ -63,7 +63,7 @@ func main() {
 
 	// Interactors
 	createUser := userInteractors.NewCreateUser(logrus.Get("CreateUser"), usersProxy)
-	createToken := userInteractors.NewCreateToken(logrus.Get("CreateToken"), usersProxy, authnProxy)
+	createToken := userInteractors.NewCreateToken(logrus.Get("CreateToken"), usersProxy, authProxy)
 	createSession := userInteractors.NewCreateSession(thingProxy, generator, sessionStore)
 
 	thingInteractor := thingInteractors.NewThingInteractor(logrus.Get("ThingInteractor"), clientPublisher, thingProxy)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,8 @@ type Users struct {
 	Port     uint16
 }
 
-// Authn represents the authn service to proxy request
-type Authn struct {
+// Auth represents the auth service to proxy request
+type Auth struct {
 	Hostname string
 	Port     uint16
 }
@@ -55,7 +55,7 @@ type Config struct {
 	Server
 	Logger
 	Users
-	Authn
+	Auth
 	RabbitMQ
 	Things
 	Redis

--- a/internal/config/default.yaml
+++ b/internal/config/default.yaml
@@ -9,7 +9,7 @@ users:
   hostname: localhost
   port: 8180
 
-authn:
+auth:
   hostname: localhost
   port: 8183
 

--- a/internal/config/development.yaml
+++ b/internal/config/development.yaml
@@ -9,8 +9,8 @@ users:
   hostname: users
   port: 8180
 
-authn:
-  hostname: authn
+auth:
+  hostname: auth
   port: 8183
 
 rabbitmq:

--- a/pkg/mocks/auth_proxy.go
+++ b/pkg/mocks/auth_proxy.go
@@ -5,15 +5,15 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// FakeAuthnProxy represents a mocking type for the user's proxy service
-type FakeAuthnProxy struct {
+// FakeAuthProxy represents a mocking type for the user's proxy service
+type FakeAuthProxy struct {
 	mock.Mock
 	Token string
 	Err   error
 }
 
 // CreateAppToken provides a mock function to create a new application token
-func (fup *FakeAuthnProxy) CreateAppToken(user entities.User, duration int) (string, error) {
+func (fup *FakeAuthProxy) CreateAppToken(user entities.User, duration int) (string, error) {
 	args := fup.Called(user, duration)
 	return args.String(0), args.Error(1)
 }

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -250,8 +250,8 @@ func (p proxy) mapErrorFromStatusCode(code int) error {
 		switch code {
 		case http.StatusConflict:
 			err = errorConflict{}
-		case http.StatusForbidden:
-			err = entities.ErrThingForbidden
+		case http.StatusUnauthorized:
+			err = entities.ErrThingUnauthorized
 		}
 	}
 	return err

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -18,78 +18,79 @@ func (err errorConflict) Error() string {
 	return "error conflict"
 }
 
-// ThingProxy proxy a request to the thing service interface
+// ThingProxy is an interface to the Mainflux Things service, which provides an API for
+// managing things (logical representation of a physical thing in IoT). This interface
+// provides a set of operations to manage things (CRUD). In addition, it supports the
+// updating of thing's configuration by using the Mainflux metadata capabilities.
+// https://github.com/mainflux/mainflux/blob/0.12.1/things/openapi.yml
 type ThingProxy interface {
-	Create(id, name, authorization string) (idGenerated string, err error)
+	Create(id, name, authorization string) (string, error)
 	UpdateConfig(authorization, ID string, configList []entities.Config) error
 	List(authorization string) (things []*entities.Thing, err error)
 	Get(authorization, ID string) (*entities.Thing, error)
 	Remove(authorization, ID string) error
 }
 
-// ThingProxyRepr is the entity that represents the thing on the remote thing's service
-type ThingProxyRepr struct {
-	ID       string      `json:"id"`
-	Name     string      `json:"name"`
-	Metadata objMetadata `json:"metadata"`
-}
-
-type objMetadata struct {
-	Knot objKnot `json:"knot"`
-}
-
-type objKnot struct {
-	ID     string            `json:"id"`
-	Config []entities.Config `json:"config,omitempty"`
-}
-
-type pageFetchInput struct {
-	Total  int               `json:"total"`
-	Offset int               `json:"offset"`
-	Limit  int               `json:"limit"`
-	Things []*ThingProxyRepr `json:"things"`
-}
-
-type proxy struct {
+type thingProxy struct {
 	url    string
 	logger logging.Logger
 }
 
-// RequestInfo aims to group all request releated information
-type RequestInfo struct {
+type pageFetchSchema struct {
+	Total  int            `json:"total"`
+	Offset int            `json:"offset"`
+	Limit  int            `json:"limit"`
+	Things []*thingSchema `json:"things"`
+}
+
+type thingSchema struct {
+	ID       string        `json:"id"`
+	Name     string        `json:"name"`
+	Metadata thingMetadata `json:"metadata"`
+}
+
+type thingMetadata struct {
+	Thing knotThing `json:"knot"`
+}
+
+type knotThing struct {
+	ID     string            `json:"id"`
+	Config []entities.Config `json:"config,omitempty"`
+}
+
+type requestInfo struct {
 	method        string
 	url           string
 	authorization string
 	contentType   string
 	data          []byte
-	options       *RequestOptions
+	options       *requestOptions
 }
 
-// RequestOptions represents the request query parameters
-type RequestOptions struct {
+type requestOptions struct {
 	Limit  int `url:"limit"`
 	Offset int `url:"offset"`
 }
 
-// NewThingProxy creates a proxy to the thing service
-func NewThingProxy(logger logging.Logger, hostname, protocol string, port uint16) ThingProxy {
+// NewThingProxy creates a new things instance and returns a pointer to the ThingsProxy interface
+// implementation.
+func NewThingProxy(logger logging.Logger, hostname, protocol string, port uint16) *thingProxy {
 	url := fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
-
-	logger.Debug("proxy setup to " + url)
-	return proxy{url, logger}
+	logger.Debug("things proxy configured to " + url)
+	return &thingProxy{url, logger}
 }
 
-// Create register a thing on service and return the id generated
-func (p proxy) Create(id, name, authorization string) (idGenerated string, err error) {
-	p.logger.Debug("proxying request to create thing")
-	t := p.getRemoteThingRepr(id, name, nil)
+// Create registers a new thing in the Mainflux platform. It receives the thing's properties and
+// map them to the Mainflux internal representation. As a result, the operation returns the things
+// ID.
+func (p thingProxy) Create(id, name, authorization string) (string, error) {
+	t := p.getThingSchema(id, name, nil)
 	body, err := json.Marshal(t)
 	if err != nil {
-		p.logger.Error(err)
 		return "", err
 	}
 
-	requestInfo := &RequestInfo{
+	requestInfo := &requestInfo{
 		"POST",
 		p.url + "/things",
 		authorization,
@@ -100,39 +101,37 @@ func (p proxy) Create(id, name, authorization string) (idGenerated string, err e
 
 	resp, err := p.sendRequest(requestInfo)
 	if err != nil {
-		p.logger.Error(err)
 		return "", err
 	}
 	defer resp.Body.Close()
 
 	err = p.mapErrorFromStatusCode(resp.StatusCode)
 	if err != nil {
-		p.logger.Error(err)
 		return "", err
 	}
 
-	locationHeader := resp.Header.Get("Location")
-	thingID := locationHeader[len("/things/"):] // get substring after "/things/"
-	return thingID, nil
+	location := resp.Header.Get("Location")
+	return location[len("/things/"):], nil // get substring after "/things/"
 }
 
-// UpdateConfig receives as parameters the authorization token, thing's ID and config. After that,
-// it sends a HTTP request to the thing's service in order to update it with the new config.
-func (p proxy) UpdateConfig(authorization, ID string, configList []entities.Config) error {
+// UpdateConfig updates the internal thing's representation with the config in the format supported
+// by the KNoT protocol. KNoT Thing config has two data structures: (1) schema and (2) event.
+// (1) represents the sensor semantic models (temperature, voltage, etc).
+// (2) represents the sensor data publishing configuration (interval, custom behavior when data changes, etc).
+func (p thingProxy) UpdateConfig(authorization, ID string, configList []entities.Config) error {
 	t, err := p.Get(authorization, ID)
 	if err != nil {
 		return err
 	}
 
-	rt := p.getRemoteThingRepr(t.ID, t.Name, t.Config)
-	rt.Metadata.Knot.Config = configList
+	rt := p.getThingSchema(t.ID, t.Name, t.Config)
+	rt.Metadata.Thing.Config = configList
 	parsedBody, err := json.Marshal(rt)
 	if err != nil {
-		p.logger.Error(err)
 		return err
 	}
 
-	requestInfo := &RequestInfo{
+	requestInfo := &requestInfo{
 		"PUT",
 		p.url + "/things/" + t.Token,
 		authorization,
@@ -143,7 +142,6 @@ func (p proxy) UpdateConfig(authorization, ID string, configList []entities.Conf
 
 	resp, err := p.sendRequest(requestInfo)
 	if err != nil {
-		p.logger.Error(err)
 		return err
 	}
 	defer resp.Body.Close()
@@ -151,7 +149,10 @@ func (p proxy) UpdateConfig(authorization, ID string, configList []entities.Conf
 	return p.mapErrorFromStatusCode(resp.StatusCode)
 }
 
-func (p proxy) List(authorization string) ([]*entities.Thing, error) {
+// List returns the registered things according to the KNoT Cloud representation.
+// The Mainflux Things API blocks requests for a large number of things. Thus,
+// this method paginates over them a returns a single slice of things.
+func (p thingProxy) List(authorization string) ([]*entities.Thing, error) {
 	things := []*entities.Thing{}
 	pagThings, err := p.getPaginatedThings(authorization)
 	if err != nil {
@@ -159,14 +160,14 @@ func (p proxy) List(authorization string) ([]*entities.Thing, error) {
 	}
 
 	for _, t := range pagThings {
-		things = append(things, &entities.Thing{ID: t.Metadata.Knot.ID, Name: t.Name, Config: t.Metadata.Knot.Config})
+		things = append(things, &entities.Thing{ID: t.Metadata.Thing.ID, Name: t.Name, Config: t.Metadata.Thing.Config})
 	}
 
 	return things, err
 }
 
-// Get list the things registered on thing's service
-func (p proxy) Get(authorization, ID string) (*entities.Thing, error) {
+// Get retrieves an invidual thing from the Mainflux service. It uses the KNoT Thing's ID as filter.
+func (p thingProxy) Get(authorization, ID string) (*entities.Thing, error) {
 	things, err := p.getPaginatedThings(authorization)
 	if err != nil {
 		return nil, err
@@ -174,8 +175,8 @@ func (p proxy) Get(authorization, ID string) (*entities.Thing, error) {
 
 	for i := range things {
 		t := things[i]
-		if t.Metadata.Knot.ID == ID {
-			nt := &entities.Thing{ID: ID, Token: t.ID, Name: t.Name, Config: t.Metadata.Knot.Config}
+		if t.Metadata.Thing.ID == ID {
+			nt := &entities.Thing{ID: ID, Token: t.ID, Name: t.Name, Config: t.Metadata.Thing.Config}
 			return nt, nil
 		}
 	}
@@ -183,14 +184,14 @@ func (p proxy) Get(authorization, ID string) (*entities.Thing, error) {
 	return nil, entities.ErrThingNotFound
 }
 
-// Remove removes the indicated thing from the thing's service
-func (p proxy) Remove(authorization, ID string) error {
+// Remove removes an individual thing from the Mainflux service. It uses the KNoT Thing's ID as filter.
+func (p thingProxy) Remove(authorization, ID string) error {
 	t, err := p.Get(authorization, ID)
 	if err != nil {
 		return err
 	}
 
-	requestInfo := &RequestInfo{
+	requestInfo := &requestInfo{
 		"DELETE",
 		p.url + "/things/" + t.Token,
 		authorization,
@@ -208,11 +209,11 @@ func (p proxy) Remove(authorization, ID string) error {
 	return p.mapErrorFromStatusCode(resp.StatusCode)
 }
 
-func (p proxy) getRemoteThingRepr(id, name string, configList []entities.Config) ThingProxyRepr {
-	return ThingProxyRepr{
+func (p thingProxy) getThingSchema(id, name string, configList []entities.Config) thingSchema {
+	return thingSchema{
 		Name: name,
-		Metadata: objMetadata{
-			Knot: objKnot{
+		Metadata: thingMetadata{
+			Thing: knotThing{
 				ID:     id,
 				Config: configList,
 			},
@@ -220,70 +221,31 @@ func (p proxy) getRemoteThingRepr(id, name string, configList []entities.Config)
 	}
 }
 
-func (p proxy) sendRequest(info *RequestInfo) (*http.Response, error) {
-	values, err := query.Values(info.options)
-	if err != nil {
-		return nil, err
-	}
-	queryString := "?" + values.Encode()
-
-	/**
-	 * Add Timeout in http.Client to avoid blocking the request.
-	 */
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(info.method, info.url+queryString, bytes.NewBuffer(info.data))
-	if err != nil {
-		p.logger.Error(err)
-		return nil, err
-	}
-
-	req.Header.Set("Authorization", info.authorization)
-	req.Header.Set("Content-Type", info.contentType)
-
-	return client.Do(req)
-}
-
-func (p proxy) mapErrorFromStatusCode(code int) error {
-	var err error
-
-	if code != http.StatusCreated {
-		switch code {
-		case http.StatusConflict:
-			err = errorConflict{}
-		case http.StatusUnauthorized:
-			err = entities.ErrThingUnauthorized
-		}
-	}
-	return err
-}
-
-func (p proxy) getPaginatedThings(authorization string) ([]*ThingProxyRepr, error) {
-	requestInfo := &RequestInfo{
+func (p thingProxy) getPaginatedThings(authorization string) ([]*thingSchema, error) {
+	requestInfo := &requestInfo{
 		"GET",
 		p.url + "/things",
 		authorization,
 		"application/json",
 		nil,
-		&RequestOptions{Limit: 100, Offset: 0}, // 100 is the max number of things that can be returned
+		&requestOptions{Limit: 100, Offset: 0}, // 100 is the max number of things that can be returned
 	}
 
-	var things []*ThingProxyRepr
+	var things []*thingSchema
 	keepGoing := true
 	for keepGoing {
 		resp, err := p.sendRequest(requestInfo)
 		if err != nil {
-			p.logger.Error(err)
 			return nil, err
 		}
 		defer resp.Body.Close()
 
 		err = p.mapErrorFromStatusCode(resp.StatusCode)
 		if err != nil {
-			p.logger.Error(err)
 			return nil, err
 		}
 
-		page := &pageFetchInput{}
+		page := &pageFetchSchema{}
 		err = json.NewDecoder(resp.Body).Decode(&page)
 		if err != nil {
 			return nil, err
@@ -298,4 +260,40 @@ func (p proxy) getPaginatedThings(authorization string) ([]*ThingProxyRepr, erro
 	}
 
 	return things, nil
+}
+
+func (p thingProxy) sendRequest(info *requestInfo) (*http.Response, error) {
+	values, err := query.Values(info.options)
+	if err != nil {
+		return nil, err
+	}
+	queryString := "?" + values.Encode()
+
+	/**
+	 * Add Timeout in http.Client to avoid blocking the request.
+	 */
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(info.method, info.url+queryString, bytes.NewBuffer(info.data))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", info.authorization)
+	req.Header.Set("Content-Type", info.contentType)
+
+	return client.Do(req)
+}
+
+func (p thingProxy) mapErrorFromStatusCode(code int) error {
+	var err error
+
+	if code != http.StatusCreated {
+		switch code {
+		case http.StatusConflict:
+			err = errorConflict{}
+		case http.StatusUnauthorized:
+			err = entities.ErrThingUnauthorized
+		}
+	}
+	return err
 }

--- a/pkg/thing/entities/errors.go
+++ b/pkg/thing/entities/errors.go
@@ -3,8 +3,8 @@ package entities
 import "errors"
 
 var (
-	// ErrThingForbidden represents the error when thing cannot be authenticated
-	ErrThingForbidden = errors.New("forbidden to authenticate thing")
+	// ErrThingUnauthorized represents the error when thing cannot be authenticated
+	ErrThingUnauthorized = errors.New("unauthorized to authenticate thing")
 
 	// ErrThingNotFound represents the error when the schema has a invalid format
 	ErrThingNotFound = errors.New("thing not found on thing's service")

--- a/pkg/thing/interactors/auth_thing_test.go
+++ b/pkg/thing/interactors/auth_thing_test.go
@@ -43,12 +43,12 @@ var atCases = []AuthThingTestCase{
 		&mocks.FakeThingProxy{ReturnErr: entities.ErrThingNotFound},
 	},
 	{
-		"forbidden to authenticate thing",
+		"unauthorized to authenticate thing",
 		"invalid-authorization-token",
 		"8380ba096a091fb9",
-		entities.ErrThingForbidden,
+		entities.ErrThingUnauthorized,
 		&mocks.FakeLogger{},
-		&mocks.FakeThingProxy{ReturnErr: entities.ErrThingForbidden},
+		&mocks.FakeThingProxy{ReturnErr: entities.ErrThingUnauthorized},
 	},
 	{
 		"allowed to authenticate thing",

--- a/pkg/user/interactors/create_token.go
+++ b/pkg/user/interactors/create_token.go
@@ -11,12 +11,12 @@ import (
 type CreateToken struct {
 	logger     logging.Logger
 	usersProxy http.UsersProxy
-	authnProxy http.AuthnProxy
+	authProxy  http.AuthProxy
 }
 
 // NewCreateToken creates a new CreateToken instance by receiving its dependencies.
-func NewCreateToken(logger logging.Logger, usersProxy http.UsersProxy, authnProxy http.AuthnProxy) *CreateToken {
-	return &CreateToken{logger, usersProxy, authnProxy}
+func NewCreateToken(logger logging.Logger, usersProxy http.UsersProxy, authProxy http.AuthProxy) *CreateToken {
+	return &CreateToken{logger, usersProxy, authProxy}
 }
 
 // Execute receives the user entity filled with e-mail and password properties and try
@@ -25,7 +25,7 @@ func (ct *CreateToken) Execute(user entities.User, tokenType string, duration in
 	if tokenType == "user" {
 		token, err = ct.usersProxy.CreateToken(user)
 	} else if tokenType == "app" {
-		token, err = ct.authnProxy.CreateAppToken(user, duration)
+		token, err = ct.authProxy.CreateAppToken(user, duration)
 	} else {
 		err = entities.ErrInvalidTokenType
 	}

--- a/pkg/user/interactors/create_token_test.go
+++ b/pkg/user/interactors/create_token_test.go
@@ -22,7 +22,7 @@ type createTokenTestCase struct {
 	expected       createTokenResponse
 	fakeLogger     *mocks.FakeLogger
 	fakeUsersProxy *mocks.FakeUsersProxy
-	fakeAuthnProxy *mocks.FakeAuthnProxy
+	fakeAuthProxy  *mocks.FakeAuthProxy
 }
 
 var (
@@ -33,7 +33,7 @@ var (
 	}
 	mockedToken   = "mocked-token"
 	errUsersProxy = errors.New("fail to create a user token")
-	errAuthnProxy = errors.New("fail to create a app token")
+	errAuthProxy  = errors.New("fail to create a app token")
 )
 
 var ctCases = []createTokenTestCase{
@@ -45,7 +45,7 @@ var ctCases = []createTokenTestCase{
 		createTokenResponse{mockedToken, nil},
 		&mocks.FakeLogger{},
 		&mocks.FakeUsersProxy{Token: mockedToken},
-		&mocks.FakeAuthnProxy{},
+		&mocks.FakeAuthProxy{},
 	},
 	{
 		"app token successfully created",
@@ -55,7 +55,7 @@ var ctCases = []createTokenTestCase{
 		createTokenResponse{mockedToken, nil},
 		&mocks.FakeLogger{},
 		&mocks.FakeUsersProxy{},
-		&mocks.FakeAuthnProxy{Token: mockedToken},
+		&mocks.FakeAuthProxy{Token: mockedToken},
 	},
 	{
 		"failed to create user token when something goes wrong in usersProxy",
@@ -65,17 +65,17 @@ var ctCases = []createTokenTestCase{
 		createTokenResponse{"", errUsersProxy},
 		&mocks.FakeLogger{},
 		&mocks.FakeUsersProxy{Err: errUsersProxy},
-		&mocks.FakeAuthnProxy{},
+		&mocks.FakeAuthProxy{},
 	},
 	{
-		"failed to create app token when something goes wrong in authnProxy",
+		"failed to create app token when something goes wrong in authProxy",
 		mockedUser,
 		"app",
 		3600,
-		createTokenResponse{"", errAuthnProxy},
+		createTokenResponse{"", errAuthProxy},
 		&mocks.FakeLogger{},
 		&mocks.FakeUsersProxy{},
-		&mocks.FakeAuthnProxy{Err: errAuthnProxy},
+		&mocks.FakeAuthProxy{Err: errAuthProxy},
 	},
 	{
 		"fail to create a token when the tokenType is invalid",
@@ -85,7 +85,7 @@ var ctCases = []createTokenTestCase{
 		createTokenResponse{"", entities.ErrInvalidTokenType},
 		&mocks.FakeLogger{},
 		&mocks.FakeUsersProxy{},
-		&mocks.FakeAuthnProxy{},
+		&mocks.FakeAuthProxy{},
 	},
 }
 
@@ -95,11 +95,11 @@ func TestCreateToken(t *testing.T) {
 			tc.fakeUsersProxy.
 				On("CreateToken", tc.user).
 				Return(tc.fakeUsersProxy.Token, tc.fakeUsersProxy.Err)
-			tc.fakeAuthnProxy.
+			tc.fakeAuthProxy.
 				On("CreateAppToken", tc.user, tc.duration).
-				Return(tc.fakeAuthnProxy.Token, tc.fakeUsersProxy.Err)
+				Return(tc.fakeAuthProxy.Token, tc.fakeUsersProxy.Err)
 
-			createTokenInteractor := NewCreateToken(tc.fakeLogger, tc.fakeUsersProxy, tc.fakeAuthnProxy)
+			createTokenInteractor := NewCreateToken(tc.fakeLogger, tc.fakeUsersProxy, tc.fakeAuthProxy)
 			token, err := createTokenInteractor.Execute(tc.user, tc.tokenType, tc.duration)
 
 			assert.Equal(t, tc.expected.token, token)
@@ -111,7 +111,7 @@ func TestCreateToken(t *testing.T) {
 				tc.fakeUsersProxy.AssertExpectations(t)
 			}
 			if tc.tokenType == "app" {
-				tc.fakeAuthnProxy.AssertExpectations(t)
+				tc.fakeAuthProxy.AssertExpectations(t)
 			}
 		})
 	}


### PR DESCRIPTION
**Describe what this PR introduces:**

In the Mainflux 0.12.0 version, the things service API is now returning unauthorized error (HTTP 401) instead of forbidden error (HTTP 403) for failures in operations that receive an invalid token.

New version: https://github.com/mainflux/mainflux/blob/0.12.1/things/openapi.yml#L25

To make it compatible with the newer version, this patch updates the error handling and the appropriate tests.

In addition, this PR makes a refactor in the things proxy component to improve readability and maintainability.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bug fix
- [ ] Feature
- [ ] Code style update
- [X] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [X] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

The user must ensure the Mainflux services running in the stack are in 0.12.1 version. Check this PR: https://github.com/CESARBR/knot-cloud/pull/55. 

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [X] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: Ubuntu 18.04
- Go version: 1.16

If you have relevant logs, error output and etc, please attach them.

**Other information:**
