### PR TITLE
Add cache to reduce Mainflux requests

### DIFF
--- a/pkg/server/handler.go
+++ b/pkg/server/handler.go
@@ -1,11 +1,10 @@
 package server
 
 import (
-	"errors"
-
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
 	"github.com/CESARBR/knot-babeltower/pkg/network"
 	"github.com/CESARBR/knot-babeltower/pkg/thing/controllers"
+	"github.com/CESARBR/knot-babeltower/pkg/thing/interactors"
 )
 
 // API definition to enable receiving request-reply commands from the clients
@@ -97,8 +96,8 @@ func (mc *MsgHandler) onMsgReceived(msgChan chan network.InMsg) {
 		mc.logger.Infof("message received: %s", string(msg.Body))
 
 		token, ok := msg.Headers["Authorization"].(string)
-		if !ok {
-			mc.logger.Error(errors.New("authorization token not provided"))
+		if !ok || token == "" {
+			mc.logger.Error(interactors.ErrAuthNotProvided)
 			continue
 		}
 

--- a/pkg/thing/delivery/amqp/client.go
+++ b/pkg/thing/delivery/amqp/client.go
@@ -144,7 +144,6 @@ func (mp *msgClientPublisher) PublishBroadcastData(thingID, token string, data [
 
 // PublishSegmentedData publishes user-tracked thing's data
 func (mp *msgClientPublisher) PublishSegmentedData(thingID, token string, data []entities.Data) error {
-	mp.logger.Debug("publishing user-tracked data")
 	msg := network.NewMessage(network.DataSent{ID: thingID, Data: data})
 	options := &network.MessageOptions{Authorization: token, Expiration: dataExpirationTime}
 

--- a/pkg/thing/delivery/http/thing_proxy.go
+++ b/pkg/thing/delivery/http/thing_proxy.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/CESARBR/knot-babeltower/pkg/logging"
 	"github.com/CESARBR/knot-babeltower/pkg/thing/entities"
 	"github.com/google/go-querystring/query"
 )
+
+const maxNumberThingsThatCanBeReturned = 100
 
 type errorConflict struct{ error }
 
@@ -32,8 +35,10 @@ type ThingProxy interface {
 }
 
 type thingProxy struct {
-	url    string
-	logger logging.Logger
+	url       string
+	logger    logging.Logger
+	cache     map[string]*entities.Thing
+	cacheLock *sync.Mutex
 }
 
 type pageFetchSchema struct {
@@ -77,13 +82,16 @@ type requestOptions struct {
 func NewThingProxy(logger logging.Logger, hostname, protocol string, port uint16) *thingProxy {
 	url := fmt.Sprintf("%s://%s:%d", protocol, hostname, port)
 	logger.Debug("things proxy configured to " + url)
-	return &thingProxy{url, logger}
+	cache := make(map[string]*entities.Thing)
+	cacheLock := &sync.Mutex{}
+	return &thingProxy{url, logger, cache, cacheLock}
 }
 
 // Create registers a new thing in the Mainflux platform. It receives the thing's properties and
 // map them to the Mainflux internal representation. As a result, the operation returns the things
 // ID.
 func (p thingProxy) Create(id, name, authorization string) (string, error) {
+	p.logger.Info("Creating thing")
 	t := p.getThingSchema(id, name, nil)
 	body, err := json.Marshal(t)
 	if err != nil {
@@ -119,6 +127,7 @@ func (p thingProxy) Create(id, name, authorization string) (string, error) {
 // (1) represents the sensor semantic models (temperature, voltage, etc).
 // (2) represents the sensor data publishing configuration (interval, custom behavior when data changes, etc).
 func (p thingProxy) UpdateConfig(authorization, ID string, configList []entities.Config) error {
+	p.logger.Info("Updating config")
 	t, err := p.Get(authorization, ID)
 	if err != nil {
 		return err
@@ -145,14 +154,22 @@ func (p thingProxy) UpdateConfig(authorization, ID string, configList []entities
 		return err
 	}
 	defer resp.Body.Close()
-
+	updatedThing := thingFactory(t.ID, t.Token, t.Name, configList)
+	updateCache(p.cache, ID, updatedThing, p.cacheLock)
 	return p.mapErrorFromStatusCode(resp.StatusCode)
+}
+
+func updateCache(cache map[string]*entities.Thing, ID string, thing *entities.Thing, lock *sync.Mutex) {
+	lock.Lock()
+	cache[ID] = thing
+	lock.Unlock()
 }
 
 // List returns the registered things according to the KNoT Cloud representation.
 // The Mainflux Things API blocks requests for a large number of things. Thus,
 // this method paginates over them a returns a single slice of things.
 func (p thingProxy) List(authorization string) ([]*entities.Thing, error) {
+	p.logger.Info("Listing things")
 	things := []*entities.Thing{}
 	pagThings, err := p.getPaginatedThings(authorization)
 	if err != nil {
@@ -168,24 +185,48 @@ func (p thingProxy) List(authorization string) ([]*entities.Thing, error) {
 
 // Get retrieves an invidual thing from the Mainflux service. It uses the KNoT Thing's ID as filter.
 func (p thingProxy) Get(authorization, ID string) (*entities.Thing, error) {
-	things, err := p.getPaginatedThings(authorization)
-	if err != nil {
-		return nil, err
-	}
+	cachedThing, ok := getThingFromCache(p.cache, ID, p.cacheLock)
+	if ok {
+		return cachedThing, nil
+	} else {
+		p.logger.Infof("Not cached thing ID: %s\n", ID)
+		things, err := p.getPaginatedThings(authorization)
+		if err != nil {
+			return nil, err
+		}
 
-	for i := range things {
-		t := things[i]
-		if t.Metadata.Thing.ID == ID {
-			nt := &entities.Thing{ID: ID, Token: t.ID, Name: t.Name, Config: t.Metadata.Thing.Config}
+		specifiedThing := findSpecifiedThing(things, ID)
+		if specifiedThing != nil {
+			nt := thingFactory(ID, specifiedThing.ID, specifiedThing.Name, specifiedThing.Metadata.Thing.Config)
+			updateCache(p.cache, ID, nt, p.cacheLock)
 			return nt, nil
 		}
+		return nil, entities.ErrThingNotFound
 	}
+}
+func findSpecifiedThing(things []*thingSchema, ID string) *thingSchema {
+	for _, thing := range things {
+		if thing.Metadata.Thing.ID == ID {
+			return thing
+		}
+	}
+	return nil
+}
 
-	return nil, entities.ErrThingNotFound
+func thingFactory(ID string, token string, name string, config []entities.Config) *entities.Thing {
+	return &entities.Thing{ID: ID, Token: token, Name: name, Config: config}
+}
+
+func getThingFromCache(cache map[string]*entities.Thing, ID string, lock *sync.Mutex) (*entities.Thing, bool) {
+	lock.Lock()
+	thing, ok := cache[ID]
+	lock.Unlock()
+	return thing, ok
 }
 
 // Remove removes an individual thing from the Mainflux service. It uses the KNoT Thing's ID as filter.
 func (p thingProxy) Remove(authorization, ID string) error {
+	p.logger.Info("Removing thing")
 	t, err := p.Get(authorization, ID)
 	if err != nil {
 		return err
@@ -205,8 +246,14 @@ func (p thingProxy) Remove(authorization, ID string) error {
 		return err
 	}
 	defer resp.Body.Close()
-
+	removeThingFromCache(p.cache, ID, p.cacheLock)
 	return p.mapErrorFromStatusCode(resp.StatusCode)
+}
+
+func removeThingFromCache(cache map[string]*entities.Thing, ID string, lock *sync.Mutex) {
+	lock.Lock()
+	delete(cache, ID)
+	lock.Unlock()
 }
 
 func (p thingProxy) getThingSchema(id, name string, configList []entities.Config) thingSchema {
@@ -228,7 +275,7 @@ func (p thingProxy) getPaginatedThings(authorization string) ([]*thingSchema, er
 		authorization,
 		"application/json",
 		nil,
-		&requestOptions{Limit: 100, Offset: 0}, // 100 is the max number of things that can be returned
+		&requestOptions{Limit: maxNumberThingsThatCanBeReturned, Offset: 0},
 	}
 
 	var things []*thingSchema
@@ -286,14 +333,18 @@ func (p thingProxy) sendRequest(info *requestInfo) (*http.Response, error) {
 
 func (p thingProxy) mapErrorFromStatusCode(code int) error {
 	var err error
-
+	errorMapping := httpCodeErrorMappingFactory()
 	if code != http.StatusCreated {
-		switch code {
-		case http.StatusConflict:
-			err = errorConflict{}
-		case http.StatusUnauthorized:
-			err = entities.ErrThingUnauthorized
-		}
+		err = errorMapping[code]
 	}
 	return err
+}
+
+func httpCodeErrorMappingFactory() map[int]error {
+	const conflictHTTPCode = 409
+	const unauthorizedHTTPCode = 401
+	errorMapping := make(map[int]error)
+	errorMapping[conflictHTTPCode] = errorConflict{}
+	errorMapping[unauthorizedHTTPCode] = entities.ErrThingUnauthorized
+	return errorMapping
 }

--- a/pkg/thing/interactors/auth_thing.go
+++ b/pkg/thing/interactors/auth_thing.go
@@ -4,9 +4,6 @@ import "fmt"
 
 // Auth is responsible to implement the thing's authentication use case
 func (i *ThingInteractor) Auth(authorization, id string) error {
-	if authorization == "" {
-		return ErrAuthNotProvided
-	}
 	if id == "" {
 		return ErrIDNotProvided
 	}

--- a/pkg/thing/interactors/list_things.go
+++ b/pkg/thing/interactors/list_things.go
@@ -8,9 +8,6 @@ import (
 
 // List fetchs the registered things and return them as an array
 func (i *ThingInteractor) List(authorization string) ([]*entities.Thing, error) {
-	if authorization == "" {
-		return nil, ErrAuthNotProvided
-	}
 
 	things, err := i.thingProxy.List(authorization)
 	if err != nil {

--- a/pkg/thing/interactors/publish_data.go
+++ b/pkg/thing/interactors/publish_data.go
@@ -9,9 +9,6 @@ import (
 
 // PublishData executes the use case operations to publish data from the things to cloud
 func (i *ThingInteractor) PublishData(authorization, thingID string, data []entities.Data) error {
-	if authorization == "" {
-		return ErrAuthNotProvided
-	}
 	if thingID == "" {
 		return ErrIDNotProvided
 	}

--- a/pkg/thing/interactors/register_thing.go
+++ b/pkg/thing/interactors/register_thing.go
@@ -11,9 +11,6 @@ const errorRegisteringThingMessage = "error registering thing"
 
 // Register runs the use case to create a new thing
 func (i *ThingInteractor) Register(authorization, id, name string) error {
-	if authorization == "" {
-		return ErrAuthNotProvided
-	}
 	if id == "" {
 		return ErrIDNotProvided
 	}

--- a/pkg/thing/interactors/request_data.go
+++ b/pkg/thing/interactors/request_data.go
@@ -8,9 +8,6 @@ import (
 
 // RequestData executes the use case operations to request data from the thing
 func (i *ThingInteractor) RequestData(authorization, thingID string, sensorIds []int) error {
-	if authorization == "" {
-		return ErrAuthNotProvided
-	}
 	if thingID == "" {
 		return ErrIDNotProvided
 	}

--- a/pkg/thing/interactors/unregister_thing.go
+++ b/pkg/thing/interactors/unregister_thing.go
@@ -4,10 +4,6 @@ package interactors
 func (i *ThingInteractor) Unregister(authorization, id string) error {
 	i.logger.Debug("executing unregister thing use case")
 
-	if authorization == "" {
-		return ErrAuthNotProvided
-	}
-
 	if id == "" {
 		return ErrIDNotProvided
 	}

--- a/pkg/thing/interactors/update_config.go
+++ b/pkg/thing/interactors/update_config.go
@@ -55,9 +55,6 @@ var rules = map[int]schemaType{
 //   - error: indicates if something goes wrong
 //   - bool: indicates if the operation has changed something in the current thing's configuration
 func (i *ThingInteractor) UpdateConfig(authorization, id string, configList []entities.Config) (bool, error) {
-	if authorization == "" {
-		return false, ErrAuthNotProvided
-	}
 	if id == "" {
 		return false, ErrIDNotProvided
 	}

--- a/pkg/thing/interactors/update_data.go
+++ b/pkg/thing/interactors/update_data.go
@@ -84,22 +84,14 @@ func validateSchema(data entities.Data, configList []entities.Config) bool {
 	return false
 }
 
-// ValidateSchemaNumber validates the value received against its type defined in the sensor's schema
-func ValidateSchemaNumber(value float64, valueType int) bool {
-	switch valueType {
-	case intType:
-		return isValidInt(value)
-	case floatType:
-		return isValidFloat(value)
-	case int64Type:
-		return isValidInt64(value)
-	case uintType:
-		return isValidUint(value)
-	case uint64Type:
-		return isValidUint64(value)
-	default: // Not a number
-		return false
-	}
+func createValueValidatorMapping() map[int]func(value float64) bool {
+	valueValidatorMapping := make(map[int]func(value float64) bool)
+	valueValidatorMapping[intType] = isValidInt
+	valueValidatorMapping[floatType] = isValidFloat
+	valueValidatorMapping[int64Type] = isValidInt64
+	valueValidatorMapping[uintType] = isValidUint
+	valueValidatorMapping[uint64Type] = isValidUint64
+	return valueValidatorMapping
 }
 
 func isValidInt(value float64) bool {
@@ -116,4 +108,14 @@ func isValidUint(value float64) bool {
 }
 func isValidUint64(value float64) bool {
 	return value >= 0 && value <= math.MaxUint64
+}
+
+// Validates the value received against its type defined in the sensor's schema
+func ValidateSchemaNumber(value float64, valueType int) bool {
+	valueValidatorMapping := createValueValidatorMapping()
+	if function, ok := valueValidatorMapping[valueType]; ok {
+		return function(value)
+	} else {
+		return false
+	}
 }


### PR DESCRIPTION
<!--
This Pull Request Template is a modified version from Vuejs's:
https://raw.githubusercontent.com/vuejs/vue/dev/.github/PULL_REQUEST_TEMPLATE.md
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Describe what this PR introduces:** (if necessary, link currently open issues with [special keywords](https://help.github.com/en/articles/closing-issues-using-keywords))

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bug fix
- [x] Feature
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce any breaking changes?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:
This PR reduces the number of requests to Mainflux's things service, which significantly increases the scalability of babeltower. This update is transparent to babeltower things and customers.

**The PR fulfills these requirements:**

- [ ] Related issues are referenced in the PR (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

**Testing environment:**

- Operating System/Platform: Ubuntu 20.4.
- Go version: ¨1.16.

If you have relevant logs, error output and etc, please attach them.

**Other information:**
